### PR TITLE
Add GitHub issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,12 @@
+*Please fill in the fields below to submit an issue or feature request.  The
+more information that is provided, the better.*
+
+**Description of issue or feature request**:
+
+
+**Current behavior**:
+
+
+**Expected behavior**:
+
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+*Please fill in the fields below to submit a pull request.  The more
+information that is provided, the better.*
+
+**Fixes issue #**:
+
+
+**Description of pull request**:
+
+
+**Please verify and check that the pull request fulfills the following
+requirements**:
+
+- [ ] Tests have been added for the bug fix or new feature
+- [ ] Docs have been added for the bug fix or new feature
+
+


### PR DESCRIPTION
The templates are taken from [in-toto/in-toto](https://github.com/in-toto/in-toto/tree/develop/.github) and slightly modified, i.e. texts are stripped down and re-formatted a little bit and the link to the [python code style guidelines](https://github.com/secure-systems-lab/code-style-guidelines) is removed (we don't have a code style guideline for go yet).

Fixes #2 