### PR TITLE
Configure travis, appveyor and coveralls configuration files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: go
+
+go:
+  - "1.11"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,9 @@ language: go
 
 go:
   - "1.11"
+
+before_install:
+  - go get github.com/mattn/goveralls
+
+script:
+  - $GOPATH/bin/goveralls -service=travis-ci

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Go in-toto verification
+[![Build Status](https://travis-ci.com/in-toto/in-toto-golang.svg?branch=master)](https://travis-ci.com/in-toto/in-toto-golang)
 
 Basic Go implementation of in-toto supply chain verification, based on the
 [in-toto Python reference implementation](https://github.com/in-toto/in-toto).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Go in-toto verification
-[![Build Status](https://travis-ci.com/in-toto/in-toto-golang.svg?branch=master)](https://travis-ci.com/in-toto/in-toto-golang)
+[![Build Status](https://travis-ci.com/in-toto/in-toto-golang.svg?branch=master)](https://travis-ci.com/in-toto/in-toto-golang) [![Coverage Status](https://coveralls.io/repos/github/in-toto/in-toto-golang/badge.svg)](https://coveralls.io/github/in-toto/in-toto-golang)
 
 Basic Go implementation of in-toto supply chain verification, based on the
 [in-toto Python reference implementation](https://github.com/in-toto/in-toto).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Go in-toto verification
-[![Build Status](https://travis-ci.com/in-toto/in-toto-golang.svg?branch=master)](https://travis-ci.com/in-toto/in-toto-golang) [![Coverage Status](https://coveralls.io/repos/github/in-toto/in-toto-golang/badge.svg)](https://coveralls.io/github/in-toto/in-toto-golang)
+[![Build Status](https://travis-ci.com/in-toto/in-toto-golang.svg?branch=master)](https://travis-ci.com/in-toto/in-toto-golang) [![Coverage Status](https://coveralls.io/repos/github/in-toto/in-toto-golang/badge.svg)](https://coveralls.io/github/in-toto/in-toto-golang) [![Build status](https://ci.appveyor.com/api/projects/status/n45pmpso0t5b40vk?svg=true)](https://ci.appveyor.com/project/in-toto/in-toto-golang)
+
 
 Basic Go implementation of in-toto supply chain verification, based on the
 [in-toto Python reference implementation](https://github.com/in-toto/in-toto).

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 build: off
 
-clone_folder: c:\gopath\src\github.com\$username\$project
+clone_folder: c:\gopath\src\github.com\in-toto\in-toto-golang
 
 environment:
   GOPATH: c:\gopath

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,11 @@
+build: off
+
+clone_folder: c:\gopath\src\github.com\$username\$project
+
+environment:
+  GOPATH: c:\gopath
+
+stack: go 1.11
+
+test_script:
+  - go test ./...


### PR DESCRIPTION
Closes #3 

- Adds configuration files for [travis](https://travis-ci.com/in-toto/in-toto-golang), [appveyor](https://ci.appveyor.com/project/lukpueh/in-toto-golang) and [coveralls](https://coveralls.io/github/in-toto/in-toto-golang).
- Adds badges about build status and test coverage to README.

TODO: Authorize build on appveyor in-toto organization and update badge url (currently the build runs on appveyor user account "lukpueh").
