### PR TITLE
Clean up InTotoVerify and rsa public key loading

### DIFF
--- a/in_toto/model.go
+++ b/in_toto/model.go
@@ -38,13 +38,17 @@ type Link struct {
 const LinkNameFormat = "%s.%.8s.link"
 const LinkNameFormatShort = "%s.link"
 
-type Inspection struct {
-  Type string `json:"_type"`
-  Run []string `json:"run"`
-  // TODO: Abstraction for Steps and Inspections?
+
+type SupplyChainItem struct {
   Name string  `json:"name"`
   ExpectedMaterials [][]string `json:"expected_materials"`
   ExpectedProducts [][]string `json:"expected_products"`
+}
+
+type Inspection struct {
+  Type string `json:"_type"`
+  Run []string `json:"run"`
+  SupplyChainItem
 }
 
 type Step struct {
@@ -52,11 +56,7 @@ type Step struct {
   PubKeys []string `json:"pubkeys"`
   ExpectedCommand []string `json:"expected_command"`
   Threshold int `json:"threshold"`
-
-  // TODO: Abstraction for Steps and Inspections?
-  Name string  `json:"name"`
-  ExpectedMaterials [][]string `json:"expected_materials"`
-  ExpectedProducts [][]string `json:"expected_products"`
+  SupplyChainItem
 }
 
 type Layout struct {

--- a/in_toto/model.go
+++ b/in_toto/model.go
@@ -76,14 +76,14 @@ type Layout struct {
 func (l *Layout) StepsAsInterfaceSlice() []interface{} {
   stepsI := make([]interface{}, len(l.Steps))
   for i, v := range l.Steps {
-      stepsI[i] = v
+    stepsI[i] = v
   }
   return stepsI
 }
 func (l *Layout) InspectAsInterfaceSlice() []interface{} {
   inspectionsI := make([]interface{}, len(l.Inspect))
   for i, v := range l.Inspect {
-      inspectionsI[i] = v
+    inspectionsI[i] = v
   }
   return inspectionsI
 }

--- a/in_toto/model.go
+++ b/in_toto/model.go
@@ -69,7 +69,7 @@ type Layout struct {
 }
 
 // Go does not allow to pass `[]T` (slice with certain type) to a function
-// the accepts `[]interface{}` (slice with generic type)
+// that accepts `[]interface{}` (slice with generic type)
 // We have to manually create the interface slice first, see
 // https://golang.org/doc/faq#convert_slice_of_interface
 // TODO: Is there a better way to do polymorphism for steps and inspections?

--- a/in_toto/model.go
+++ b/in_toto/model.go
@@ -68,6 +68,27 @@ type Layout struct {
   Readme string `json:"readme"`
 }
 
+// Go does not allow to pass `[]T` (slice with certain type) to a function
+// the accepts `[]interface{}` (slice with generic type)
+// We have to manually create the interface slice first, see
+// https://golang.org/doc/faq#convert_slice_of_interface
+// TODO: Is there a better way to do polymorphism for steps and inspections?
+func (l *Layout) StepsAsInterfaceSlice() []interface{} {
+  stepsI := make([]interface{}, len(l.Steps))
+  for i, v := range l.Steps {
+      stepsI[i] = v
+  }
+  return stepsI
+}
+func (l *Layout) InspectAsInterfaceSlice() []interface{} {
+  inspectionsI := make([]interface{}, len(l.Inspect))
+  for i, v := range l.Inspect {
+      inspectionsI[i] = v
+  }
+  return inspectionsI
+}
+
+
 type Metablock struct {
   // NOTE: Whenever we want to access an attribute of `Signed` we have to
   // perform type assertion, e.g. `metablock.Signed.(Layout).Keys`

--- a/in_toto/verifylib.go
+++ b/in_toto/verifylib.go
@@ -477,15 +477,8 @@ func InTotoVerify(layoutPath string, layoutKeys map[string]Key,
     return err
   }
 
-  // Go does not allow to pass []Step as []interface{}
-  // We have to manually copy first :(
-  // https://golang.org/doc/faq#convert_slice_of_interface
-  stepsI := make([]interface{}, len(layout.Steps))
-  for i, v := range layout.Steps {
-      stepsI[i] = v
-  }
   // Verify artifact rules
-  if err := VerifyArtifacts(stepsI, stepsMetadataReduced); err != nil {
+  if err := VerifyArtifacts(layout.StepsAsInterfaceSlice(), stepsMetadataReduced); err != nil {
     return err
   }
 
@@ -500,18 +493,9 @@ func InTotoVerify(layoutPath string, layoutKeys map[string]Key,
     inspectionMetadata[k] = v
   }
 
-  // Convert []Inspections to []interace{} (see `stepsI` above)
-  inspectionsI := make([]interface{}, len(layout.Inspect))
-  for i, v := range layout.Inspect {
-      inspectionsI[i] = v
-  }
-
-  if err := VerifyArtifacts(inspectionsI, inspectionMetadata); err != nil {
+  if err := VerifyArtifacts(layout.InspectAsInterfaceSlice(), inspectionMetadata); err != nil {
     return err
   }
 
   return nil
 }
-
-
-


### PR DESCRIPTION
This PR provides a few small code refactors for clean up:
- Summarize common functionality used in keylib VerifySignature and LoadPublicKey #7 
- Move type juggeling loops from InTotoVerify to helper methods #6 
- Implement go-thonic field inheritance for common fields of steps/inspections