### PR TITLE
Add docs and testable example

### DIFF
--- a/in_toto/examples_test.go
+++ b/in_toto/examples_test.go
@@ -1,0 +1,34 @@
+package in_toto
+
+import (
+  "os"
+  "fmt"
+  )
+
+const LayoutPath = "../test/data/demo.layout.template"
+const LayoutKeyPath = "../test/data/alice.pub"
+const LinkDirectory = "../test/data/"
+
+func ExampleInTotoVerify() {
+  // Load the layout verification key and create a map as is required by
+  // InTotoVerify.  The layout represents the root of trust so it is a good
+  // idea to sign it using multiple keys.
+  var pubKey Key
+  pubKey.LoadPublicKey(LayoutKeyPath);
+  var layoutKeys = map[string]Key{
+    pubKey.KeyId: pubKey,
+  }
+
+  // Perform in-toto software supply chain verification, using the provided
+  // test data.
+  err := InTotoVerify(LayoutPath, layoutKeys, LinkDirectory)
+  if err != nil {
+    fmt.Println("In-toto verification succeeded!")
+  }
+
+  // During verification the inspection "untar" was executed, generating a
+  // corresponding link metadata file "untar.link". You can safely remove it.
+  os.Remove("untar.link")
+
+  // Output: In-toto verification succeeded!
+}

--- a/in_toto/keylib.go
+++ b/in_toto/keylib.go
@@ -14,6 +14,12 @@ import (
   "reflect"
 )
 
+/*
+ParseRSAPublicKeyFromPEM parses the passed pemBytes as e.g. read from a PEM
+formatted file, and instantiates and returns the corresponding RSA public key.
+If the no RSA public key can be parsed, the first return value is nil and the
+second return value is the error.
+*/
 func ParseRSAPublicKeyFromPEM(pemBytes []byte) (*rsa.PublicKey, error) {
   // TODO: There could be more key data in _, which we silently ignore here.
   // Should we handle it / fail / say something about it?
@@ -37,6 +43,12 @@ func ParseRSAPublicKeyFromPEM(pemBytes []byte) (*rsa.PublicKey, error) {
   return rsaPub, nil
 }
 
+
+/*
+LoadPublicKey parses an RSA public key from a PEM formatted file at the passed
+path into the Key object on which it was called.  It returns an error if the
+file at path does not exist or is not a PEM formatted RSA public key.
+*/
 func (k *Key) LoadPublicKey(path string) error {
   keyFile, err := os.Open(path)
   defer keyFile.Close()
@@ -116,6 +128,11 @@ func (k *Key) LoadPublicKey(path string) error {
 }
 
 
+/*
+VerifySignature uses the passed Key to verify the passed Signature over the
+passed data.  It returns an error if the key is not a valid RSA public key or
+if the signature is not valid for the data.
+*/
 func VerifySignature(key Key, sig Signature, data []byte) error {
   // Create rsa.PublicKey object from DER encoded public key string as
   // found in the public part of the keyval part of a securesystemslib key dict

--- a/in_toto/rulelib.go
+++ b/in_toto/rulelib.go
@@ -5,6 +5,7 @@ import (
   "strings"
   )
 
+// An error message issued in UnpackRule if it receives a malformed rule.
 var errorMsg string = "Wrong rule format, available formats are:\n" +
   "\tMATCH <pattern> [IN <source-path-prefix>] WITH (MATERIALS|PRODUCTS)" +
       " [IN <destination-path-prefix>] FROM <step>,\n" +
@@ -15,14 +16,39 @@ var errorMsg string = "Wrong rule format, available formats are:\n" +
   "\tDISALLOW <pattern>\n\n"
 
 
+/*
+UnpackRule parses the passed rule and extracts and returns the information
+required for rule processing.  It can be used to verify if a rule has a valid
+format.  Available rule formats are:
+  MATCH <pattern> [IN <source-path-prefix>] WITH (MATERIALS|PRODUCTS)
+      [IN <destination-path-prefix>] FROM <step>,
+  CREATE <pattern>,
+  DELETE <pattern>,
+  MODIFY <pattern>,
+  ALLOW <pattern>,
+  DISALLOW <pattern>
 
+Rule tokens are normalized to lower case before returning.  The returned map
+has the following format:
+  {
+    "type": "match" | "create" | "delete" |"modify" | "allow" | "disallow"
+    "pattern": "<file name pattern>",
+    "srcPrefix": "<path or empty string>", // MATCH rule only
+    "dstPrefix": "<path or empty string>", // MATCH rule only
+    "dstType": "materials" | "products">, // MATCH rule only
+    "dstName": "<step name>", // Match rule only
+  }
+
+If the rule does not match any of the available formats the first return value
+is nil and the second return value is the error.
+*/
 func UnpackRule(rule []string) (map[string]string, error) {
   // Cache rule len
   ruleLen := len(rule)
 
-  // Create all lower rule copy to case insensitively parse out tokens whose
-  // position we don't know yet
-  // We keep the original rule to retain the non-token elements' case
+  // Create all lower rule copy to case-insensitively parse out tokens whose
+  // position we don't know yet. We keep the original rule to retain the
+  // non-token elements' case.
   ruleLower := make([]string, ruleLen)
   for i, val := range rule {
     ruleLower[i] = strings.ToLower(val)
@@ -102,6 +128,5 @@ func UnpackRule(rule []string) (map[string]string, error) {
     default:
       return nil,
           fmt.Errorf("%s Got:\n\t %s", errorMsg, rule)
-
   }
 }

--- a/in_toto/verifylib.go
+++ b/in_toto/verifylib.go
@@ -1,3 +1,8 @@
+/*
+Package in_toto implements types and routines to verify a software supply chain
+according to the in-toto specification.
+https://github.com/in-toto/docs/blob/master/in-toto-spec.md
+*/
 package in_toto
 
 import (

--- a/in_toto/verifylib.go
+++ b/in_toto/verifylib.go
@@ -1,7 +1,7 @@
 /*
 Package in_toto implements types and routines to verify a software supply chain
 according to the in-toto specification.
-https://github.com/in-toto/docs/blob/master/in-toto-spec.md
+See https://github.com/in-toto/docs/blob/master/in-toto-spec.md
 */
 package in_toto
 
@@ -14,6 +14,23 @@ import (
   "path/filepath"
 )
 
+
+/*
+RunInspections iteratively executes the command in the Run field of all
+inspections of the passed layout, creating unsigned link metadata that records
+all files found in the current working directory as materials (before command
+execution) and products (after command execution).  A map with inspection names
+as keys and Metablocks containing the generated link metadata as values is
+returned.  The format is:
+  {
+    <inspection name> : Metablock,
+    <inspection name> : Metablock,
+    ...
+  }
+If executing the inspection command fails, or if the executed command has a
+non-zero exit code, the first return value is nil and the second return value
+is the error.
+*/
 func RunInspections(layout Layout) (map[string]Metablock, error) {
   inspectionMetadata := make(map[string]Metablock)
 
@@ -41,9 +58,11 @@ func RunInspections(layout Layout) (map[string]Metablock, error) {
   return inspectionMetadata, nil
 }
 
+
+// Subtract is a helper function that performs set subtraction
 // TODO: This function has O(n**2), consider using maps (in linear-time)
 // https://siongui.github.io/2018/03/14/go-set-difference-of-two-arrays/, or
-// find a proper set library
+// find a proper set library.
 func Subtract(a []string, b []string) []string {
   var result []string
   for _, valA := range a {
@@ -61,7 +80,9 @@ func Subtract(a []string, b []string) []string {
   return result
 }
 
-// Mimics Python's fnmatch.filter using Go's Match from path/filepath package
+
+// FnFilter is a helper function that mimics fnmatch.filter from the Python
+// standard library using Go Match from the path/filepath package.
 func FnFilter (pattern string, names []string) []string {
   var namesFiltered []string
   for _, name := range names {
@@ -79,8 +100,24 @@ func FnFilter (pattern string, names []string) []string {
 }
 
 
+/*
+VerifyArtifacts iteratively applies the material and product rules of the
+passed items (step or inspection) to enforce and authorize artifacts (materials
+or products) reported by the corresponding link and to guarantee that
+artifacts are linked together across links.  In the beginning all artifacts are
+placed in a queue according to their type.  If an artifact gets consumed by a
+rule it is removed from the queue.  An artifact can only be consumed once by
+one set of rules.
+
+Rules of type MATCH, ALLOW and DISALLOW are supported.
+
+MATCH and ALLOW remove artifacts from the corresponding queues on success, and
+leave the queue unchanged on failure.  Hence, it is left to a subsequent
+DISALLOW rule to fail overall verification, if artifacts are left in the queue
+that should have been consumed by preceding rules.
+*/
 func VerifyArtifacts(items []interface{},
-    stepsMetadata map[string]Metablock) error {
+    itemsMetadata map[string]Metablock) error {
   // Verify artifact rules for each item in the layout
   for _, itemI := range items {
     // The layout item (interface) must be a Link or an Inspection we are only
@@ -105,7 +142,7 @@ func VerifyArtifacts(items []interface{},
             " elements of passed slice 'items' must be one of 'Step' or" +
             " 'Inspection', got: '%s'", reflect.TypeOf(item))
     }
-    srcLinkMb := stepsMetadata[itemName]
+    srcLinkMb := itemsMetadata[itemName]
 
     verificationDataList := []map[string]interface{}{
       map[string]interface{}{
@@ -125,13 +162,12 @@ func VerifyArtifacts(items []interface{},
       rules := verificationData["rules"].([][]string)
       artifacts := verificationData["artifacts"].(map[string]interface{})
 
-      // Create a queue of artifact names (paths)
-      // Each rule only operates on artifacts in that queue
-      // If a rule consumes an artifact (can be applied successfully) it is
-      // removed from the queue.
-      // By applying a DISALLOW rule eventually, verification may return an
-      // error, if the rule matches any artifacts in the queue that should
-      // have been consumed earlier.
+      // Create a queue of artifact names (paths).  Each rule only operates on
+      // artifacts in that queue.  If a rule consumes an artifact (i.e. can be
+      // applied successfully), the artifact is removed from the queue.  By
+      // applying a DISALLOW rule eventually, verification may return an error,
+      // if the rule matches any artifacts in the queue that should have been
+      // consumed earlier.
       var queue []string
       for name, _ := range artifacts {
         queue = append(queue, name)
@@ -151,7 +187,7 @@ func VerifyArtifacts(items []interface{},
         switch ruleData["type"] {
           case "match":
             // Get destination link metadata
-            dstLinkMb, exists := stepsMetadata[ruleData["dstName"]]
+            dstLinkMb, exists := itemsMetadata[ruleData["dstName"]]
             if !exists {
               // Destination link does not exist, rule can't consume any
               // artifacts
@@ -168,16 +204,15 @@ func VerifyArtifacts(items []interface{},
                 dstArtifacts = dstLinkMb.Signed.(Link).Products
             }
 
-            // Normalize optional source and destination prefixes, i.e.
-            // if there is a prefix, then add a trailing slash if not there yet
+            // Normalize optional source and destination prefixes, i.e. if
+            // there is a prefix, then add a trailing slash if not there yet
             for _, prefix := range []string{"srcPrefix", "dstPrefix"} {
               if ruleData[prefix] != "" &&
                   ! strings.HasSuffix(ruleData[prefix], "/") {
                 ruleData[prefix] += "/"
               }
             }
-            // Iterate over queue and add consumed artifacts
-            // consumed is subtracted from queue
+            // Iterate over queue and mark consumed artifacts
             var consumed []string
             for _, srcPath := range queue {
               // Remove optional source prefix from source artifact path
@@ -238,6 +273,22 @@ func VerifyArtifacts(items []interface{},
 }
 
 
+/*
+ReduceStepsMetadata merges for each step of the passed Layout all the passed
+per-functionary links into a single link, asserting that the reported Materials
+and Products are equal across links for a given step.  This function may be
+used at a time during the overall verification, where link threshold's have
+been verified and subsequent verification only needs one exemplary link per
+step.  The function returns a map with one Metablock (link) per step:
+  {
+    <step name> : Metablock,
+    <step name> : Metablock,
+    ...
+  }
+If links corresponding to the same step report different Materials or different
+Products, the first return value is nil and the second return value is the
+error.
+*/
 func ReduceStepsMetadata(layout Layout,
     stepsMetadata map[string]map[string]Metablock) (map[string]Metablock,
     error) {
@@ -282,7 +333,7 @@ func ReduceStepsMetadata(layout Layout,
               fmt.Sprintf(LinkNameFormat, step.Name, keyID))
         }
       }
-      // We haven't errored out, so we can reduce
+      // We haven't errored out, so we can reduce (i.e take the reference link)
       stepsMetadataReduced[step.Name] = referenceLinkMb
     }
   }
@@ -290,6 +341,12 @@ func ReduceStepsMetadata(layout Layout,
 }
 
 
+/*
+VerifyStepCommandAlignment (soft) verifies that for each step of the passed
+layout the command executed, as per the passed link, matches the expected
+command, as per the layout.  Soft verification means that, in case a command
+does not align, a warning is issued.
+*/
 func VerifyStepCommandAlignment(layout Layout,
     stepsMetadata map[string]map[string]Metablock) {
   for _, step := range layout.Steps {
@@ -315,29 +372,51 @@ func VerifyStepCommandAlignment(layout Layout,
 }
 
 
+/*
+VerifyLinkSignatureThesholds verifies that for each step of the passed layout,
+there are at least Threshold links, validly signed by different authorized
+functionaries.  The returned map of link metadata per steps contains only
+links with valid signatures from distinct functionaries and has the format:
+  {
+    <step name> : {
+      <key id>: Metablock,
+      <key id>: Metablock,
+      ...
+    },
+    <step name> : {
+      <key id>: Metablock,
+      <key id>: Metablock,
+      ...
+    }
+    ...
+  }
+If for any step of the layout there are not enough links available, the first
+return value is nil and the second return value is the error.
+*/
 func VerifyLinkSignatureThesholds(layout Layout,
     stepsMetadata map[string]map[string]Metablock) (
     map[string]map[string]Metablock, error) {
-  // Copy of passed stepsMetadata
-  // But only stores links with valid signature from an authorized functionary
+  // This will stores links with valid signature from an authorized functionary
+  // for all steps
   stepsMetadataVerified := make(map[string]map[string]Metablock)
 
   // Try to find enough (>= threshold) links each with a valid signature from
   // distinct authorized functionaries for each step
   for _, step := range layout.Steps {
-    // Stores links with valid signature from authorized functionary per step
+    // This will store links with valid signature from an authorized
+    // functionary for the given step
     linksPerStepVerified := make(map[string]Metablock)
 
-    // Check if there are any links at all for a given step
+    // Check if there are any links at all for the given step
     linksPerStep, ok := stepsMetadata[step.Name]
     if !ok || len(linksPerStep) < 1 {
       continue
     }
 
-    // For each link of corresponding to a step, check that the signer key
-    // was authorized, the layout contains a verification key and the
-    // signature verification passes.
-    // Only good links are stored, to verify thresholds below
+    // For each link corresponding to a step, check that the signer key was
+    // authorized, the layout contains a verification key and the signature
+    // verification passes.  Only good links are stored, to verify thresholds
+    // below.
     for signerKeyID, linkMb := range linksPerStep {
       for _, authorizedKeyID := range step.PubKeys {
         if signerKeyID == authorizedKeyID {
@@ -370,6 +449,31 @@ func VerifyLinkSignatureThesholds(layout Layout,
 }
 
 
+/*
+LoadLinksForLayout loads for every Step of the passed Layout a Metablock
+containing the corresponding Link.  A base path to a directory that contains
+the links may be passed using linkDir.  Link file names are constructed,
+using LinkNameFormat together with the corresponding step name and authorized
+functionary key ids.  A map of link metadata is returned and has the following
+format:
+  {
+    <step name> : {
+      <key id>: Metablock,
+      <key id>: Metablock,
+      ...
+    },
+    <step name> : {
+      <key id>: Metablock,
+      <key id>: Metablock,
+      ...
+    }
+    ...
+  }
+If a link cannot be loaded at a constructed link name or is invalid, it is
+ignored. Only a preliminary threshold check is performed, that is, if there
+aren't at least Threshold links for any given step, the first return value
+is nil and the second return value is the error.
+*/
 func LoadLinksForLayout(layout Layout, linkDir string)(
     map[string]map[string]Metablock, error) {
   stepsMetadata := make(map[string]map[string]Metablock)
@@ -383,7 +487,7 @@ func LoadLinksForLayout(layout Layout, linkDir string)(
 
       var linkMb Metablock
       if err := linkMb.Load(linkPath); err != nil {
-        return nil, err
+        continue
       }
 
       linksPerStep[authorizedKeyId] = linkMb
@@ -401,12 +505,16 @@ func LoadLinksForLayout(layout Layout, linkDir string)(
 }
 
 
+/*
+VerifyLayoutExpiration verifies that the passed Layout has not expired.  It
+returns an error if the (zulu) date in the Expires field is in the past.
+*/
 func VerifyLayoutExpiration(layout Layout) error {
   expires, err := time.Parse(time.RFC3339, layout.Expires)
   if err != nil {
     return err
   }
-  // Uses timesone of expires, i.e. UTC
+  // Uses timezone of expires, i.e. UTC
   if time.Until(expires) < 0 {
     return fmt.Errorf("Layout has expired on '%s'.", expires)
   }
@@ -414,6 +522,13 @@ func VerifyLayoutExpiration(layout Layout) error {
 }
 
 
+/*
+VerifyLayoutSignatures verifies for each key in the passed key map the
+corresponding signature of the Layout in the passed Metablock's Signed field.
+Signatures and keys are associated by key id.  If the key map is empty, or the
+Metablock's Signature field does not have a signature for one or more of the
+passed keys, or a matching signature is invalid, an error is returned.
+*/
 func VerifyLayoutSignatures(layoutMb Metablock,
     layoutKeys map[string]Key) error {
   if len(layoutKeys) < 1 {
@@ -429,6 +544,30 @@ func VerifyLayoutSignatures(layoutMb Metablock,
 }
 
 
+/*
+InTotoVerify can be used to verify an entire software supply chain according to
+the in-toto specification.  It requires a path to a root layout, a map that
+contains public keys to verify the root layout signatures, and a path to a
+directory from where it can load link metadata files, which are treated as
+signed evidence for the steps defined in the layout. The verification routine
+is as follows:
+
+1. Load layout
+2. Verify layout signature(s) using passed key(s)
+3. Verify layout expiration date
+4. Load link metadata files for steps of layout
+5. Verify signatures and signature thresholds for steps of layout
+6. Verify command alignment for steps of layout (only warns)
+7. Verify artifact rules for steps of layout
+8. Execute inspection commands (generates link metadata for each inspection)
+9. Verify artifact rules for inspections of layout
+
+If any of the verification routines fail, verification is aborted and an error
+is returned.
+
+NOTE: Parameter substitution, sublayout (recursive) verification and artifact
+rules of type "create", "modify" and "delete" are currently not supported.
+*/
 func InTotoVerify(layoutPath string, layoutKeys map[string]Key,
     linkDir string) error {
 


### PR DESCRIPTION
Add docstrings on package, function and structs level, and a testable example. Closes #9 

Docstring formats are roughly based on these go guidelines:
https://golang.org/doc/effective_go.html#commentary
https://github.com/golang/go/wiki/CodeReviewComments#comment-sentences

They are, however, more detailed than go docstrings usually seem to be, tending towards our rather verbose [Python guidelines](https://github.com/secure-systems-lab/code-style-guidelines).

To run a webserver that renders html pages for the docs (including the example), execute e.g. `godoc -http :6060`,
and browse http://localhost:6060/pkg/github.com/in-toto/in-toto-golang/in_toto/

*Additional notes:*
It might be worth rethinking the package structure. Currently, we have one package split in several files. Maybe we can factor out some functionality into separate packages for better name spacing and separate package documentation.

Furthermore, it might make sense to rethink which names (functions, structs, constants) should be exported (in go every name that starts with upper case is exported). Currently, we export everything.



