### PR TITLE
Auto re-format all go code using `gofmt`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,5 @@ before_install:
   - go get github.com/mattn/goveralls
 
 script:
+  - test -z $(gofmt -l in_toto)
   - $GOPATH/bin/goveralls -service=travis-ci

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,4 +8,5 @@ environment:
 stack: go 1.11
 
 test_script:
+  - ps: if (gofmt -l in_toto) { Write-Error "Use gofmt" }
   - go test ./...

--- a/in_toto/canonicaljson.go
+++ b/in_toto/canonicaljson.go
@@ -1,14 +1,14 @@
 package in_toto
 
 import (
-  "fmt"
-  "sort"
-  "regexp"
-  "bytes"
-  "encoding/json"
-  "reflect"
-  "strconv"
-  "errors"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"regexp"
+	"sort"
+	"strconv"
 )
 
 /*
@@ -18,9 +18,9 @@ http://wiki.laptop.org/go/Canonical_JSON).  String canonicalization consists of
 escaping backslashes ("\") and double quotes (") and wrapping the resulting
 string in double quotes (").
 */
-func _encode_canonical_string(s string) string  {
-  re := regexp.MustCompile(`([\"\\])`)
-  return fmt.Sprintf("\"%s\"", re.ReplaceAllString(s, "\\$1"))
+func _encode_canonical_string(s string) string {
+	re := regexp.MustCompile(`([\"\\])`)
+	return fmt.Sprintf("\"%s\"", re.ReplaceAllString(s, "\\$1"))
 }
 
 /*
@@ -30,77 +30,77 @@ http://wiki.laptop.org/go/Canonical_JSON) and write it to the passed
 *bytes.Buffer.  If canonicalization fails it returns an error.
 */
 func _encode_canonical(obj interface{}, result *bytes.Buffer) (err error) {
-  // Since this function is called recursively, we use panic if an error occurs
-  // and recover in a deferred function, which is always called before
-  // returning. There we set the error that is returned eventually.
-  defer func() {
-    if r := recover(); r != nil {
-        err = errors.New(r.(string))
-      }
-  }()
+	// Since this function is called recursively, we use panic if an error occurs
+	// and recover in a deferred function, which is always called before
+	// returning. There we set the error that is returned eventually.
+	defer func() {
+		if r := recover(); r != nil {
+			err = errors.New(r.(string))
+		}
+	}()
 
-  switch objAsserted := obj.(type) {
-    case string:
-      result.WriteString(_encode_canonical_string(objAsserted))
+	switch objAsserted := obj.(type) {
+	case string:
+		result.WriteString(_encode_canonical_string(objAsserted))
 
-    case bool:
-      if objAsserted {
-        result.WriteString("true")
-      } else {
-        result.WriteString("false")
-      }
+	case bool:
+		if objAsserted {
+			result.WriteString("true")
+		} else {
+			result.WriteString("false")
+		}
 
-    // Golang's JSON decoder, which we use before canonicalization, in order to
-    // transform any passed object to a generic JSON object, stores JSON
-    // numbers as float64. Hence, it is safe to expect all numeric values to be
-    // float64.
-    case float64:
-      // The used canonicalization spec only allows non-floating point numbers
-      result.WriteString(strconv.Itoa(int(objAsserted)))
+	// Golang's JSON decoder, which we use before canonicalization, in order to
+	// transform any passed object to a generic JSON object, stores JSON
+	// numbers as float64. Hence, it is safe to expect all numeric values to be
+	// float64.
+	case float64:
+		// The used canonicalization spec only allows non-floating point numbers
+		result.WriteString(strconv.Itoa(int(objAsserted)))
 
-    case nil:
-      result.WriteString("null")
+	case nil:
+		result.WriteString("null")
 
-    // Canonicalize slice
-    case []interface{}:
-      result.WriteString("[")
-      for i, val := range objAsserted {
-        _encode_canonical(val, result)
-        if i < (len(objAsserted) - 1) {
-          result.WriteString(",")
-        }
-      }
-      result.WriteString("]")
+	// Canonicalize slice
+	case []interface{}:
+		result.WriteString("[")
+		for i, val := range objAsserted {
+			_encode_canonical(val, result)
+			if i < (len(objAsserted) - 1) {
+				result.WriteString(",")
+			}
+		}
+		result.WriteString("]")
 
-    case map[string]interface{}:
-      result.WriteString("{")
+	case map[string]interface{}:
+		result.WriteString("{")
 
-      // Make a list of keys
-      mapKeys := []string{}
-      for key, _ := range objAsserted {
-          mapKeys = append(mapKeys, key)
-      }
-      // Sort keys
-      sort.Strings(mapKeys)
+		// Make a list of keys
+		mapKeys := []string{}
+		for key, _ := range objAsserted {
+			mapKeys = append(mapKeys, key)
+		}
+		// Sort keys
+		sort.Strings(mapKeys)
 
-      // Canonicalize map
-      for i, key := range mapKeys {
-        _encode_canonical(key, result)
-        result.WriteString(":")
-        _encode_canonical(objAsserted[key], result)
-        if i < (len(mapKeys) - 1) {
-          result.WriteString(",")
-        }
-        i++
-      }
-      result.WriteString("}")
+		// Canonicalize map
+		for i, key := range mapKeys {
+			_encode_canonical(key, result)
+			result.WriteString(":")
+			_encode_canonical(objAsserted[key], result)
+			if i < (len(mapKeys) - 1) {
+				result.WriteString(",")
+			}
+			i++
+		}
+		result.WriteString("}")
 
-    default:
-      // We recover in a deferred function defined above
-      panic(fmt.Sprintf("Can't canonicalize '%s' of type '%s'",
-          objAsserted, reflect.TypeOf(objAsserted)))
-  }
-  return nil
+	default:
+		// We recover in a deferred function defined above
+		panic(fmt.Sprintf("Can't canonicalize '%s' of type '%s'",
+			objAsserted, reflect.TypeOf(objAsserted)))
+	}
+	return nil
 }
 
 /*
@@ -110,22 +110,22 @@ http://wiki.laptop.org/go/Canonical_JSON).  If canonicalization fails the byte
 slice is nil and the second return value contains the error.
 */
 func encode_canonical(obj interface{}) ([]byte, error) {
-  // FIXME: Terrible hack to turn the passed struct into a map, converting
-  // the struct's variable names to the json key names defined in the struct
-  data, err := json.Marshal(obj)
-  if err != nil {
-    return nil, err
-  }
-  var jsonMap interface{}
-  if err := json.Unmarshal(data, &jsonMap); err != nil {
-    return nil, err
-  }
+	// FIXME: Terrible hack to turn the passed struct into a map, converting
+	// the struct's variable names to the json key names defined in the struct
+	data, err := json.Marshal(obj)
+	if err != nil {
+		return nil, err
+	}
+	var jsonMap interface{}
+	if err := json.Unmarshal(data, &jsonMap); err != nil {
+		return nil, err
+	}
 
-  // Create a buffer and write the canonicalized JSON bytes to it
-  var result bytes.Buffer
-  if err := _encode_canonical(jsonMap, &result); err != nil {
-    return nil, err
-  }
+	// Create a buffer and write the canonicalized JSON bytes to it
+	var result bytes.Buffer
+	if err := _encode_canonical(jsonMap, &result); err != nil {
+		return nil, err
+	}
 
-  return result.Bytes(), nil
+	return result.Bytes(), nil
 }

--- a/in_toto/examples_test.go
+++ b/in_toto/examples_test.go
@@ -1,34 +1,34 @@
 package in_toto
 
 import (
-  "os"
-  "fmt"
-  )
+	"fmt"
+	"os"
+)
 
 const LayoutPath = "../test/data/demo.layout.template"
 const LayoutKeyPath = "../test/data/alice.pub"
 const LinkDirectory = "../test/data/"
 
 func ExampleInTotoVerify() {
-  // Load the layout verification key and create a map as is required by
-  // InTotoVerify.  The layout represents the root of trust so it is a good
-  // idea to sign it using multiple keys.
-  var pubKey Key
-  pubKey.LoadPublicKey(LayoutKeyPath);
-  var layoutKeys = map[string]Key{
-    pubKey.KeyId: pubKey,
-  }
+	// Load the layout verification key and create a map as is required by
+	// InTotoVerify.  The layout represents the root of trust so it is a good
+	// idea to sign it using multiple keys.
+	var pubKey Key
+	pubKey.LoadPublicKey(LayoutKeyPath)
+	var layoutKeys = map[string]Key{
+		pubKey.KeyId: pubKey,
+	}
 
-  // Perform in-toto software supply chain verification, using the provided
-  // test data.
-  err := InTotoVerify(LayoutPath, layoutKeys, LinkDirectory)
-  if err != nil {
-    fmt.Println("In-toto verification succeeded!")
-  }
+	// Perform in-toto software supply chain verification, using the provided
+	// test data.
+	err := InTotoVerify(LayoutPath, layoutKeys, LinkDirectory)
+	if err != nil {
+		fmt.Println("In-toto verification succeeded!")
+	}
 
-  // During verification the inspection "untar" was executed, generating a
-  // corresponding link metadata file "untar.link". You can safely remove it.
-  os.Remove("untar.link")
+	// During verification the inspection "untar" was executed, generating a
+	// corresponding link metadata file "untar.link". You can safely remove it.
+	os.Remove("untar.link")
 
-  // Output: In-toto verification succeeded!
+	// Output: In-toto verification succeeded!
 }

--- a/in_toto/keylib.go
+++ b/in_toto/keylib.go
@@ -1,17 +1,17 @@
 package in_toto
 
 import (
-  "os"
-  "fmt"
-  "encoding/pem"
-  "encoding/hex"
-  "io/ioutil"
-  "crypto"
-  "crypto/rsa"
-  "crypto/x509"
-  "crypto/sha256"
-  "strings"
-  "reflect"
+	"crypto"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"reflect"
+	"strings"
 )
 
 /*
@@ -21,28 +21,27 @@ If the no RSA public key can be parsed, the first return value is nil and the
 second return value is the error.
 */
 func ParseRSAPublicKeyFromPEM(pemBytes []byte) (*rsa.PublicKey, error) {
-  // TODO: There could be more key data in _, which we silently ignore here.
-  // Should we handle it / fail / say something about it?
-  data, _ := pem.Decode([]byte(pemBytes))
-  if data == nil {
-    return nil, fmt.Errorf("Could not find a public key PEM block")
-  }
+	// TODO: There could be more key data in _, which we silently ignore here.
+	// Should we handle it / fail / say something about it?
+	data, _ := pem.Decode([]byte(pemBytes))
+	if data == nil {
+		return nil, fmt.Errorf("Could not find a public key PEM block")
+	}
 
-  pub, err := x509.ParsePKIXPublicKey(data.Bytes)
-  if err != nil {
-    return nil, err
-  }
+	pub, err := x509.ParsePKIXPublicKey(data.Bytes)
+	if err != nil {
+		return nil, err
+	}
 
-  //ParsePKIXPublicKey might return an rsa, dsa, or ecdsa public key
-  rsaPub, isRsa := pub.(*rsa.PublicKey)
-  if !isRsa {
-    return nil, fmt.Errorf("We currently only support rsa keys: got '%s'",
-        reflect.TypeOf(pub))
-  }
+	//ParsePKIXPublicKey might return an rsa, dsa, or ecdsa public key
+	rsaPub, isRsa := pub.(*rsa.PublicKey)
+	if !isRsa {
+		return nil, fmt.Errorf("We currently only support rsa keys: got '%s'",
+			reflect.TypeOf(pub))
+	}
 
-  return rsaPub, nil
+	return rsaPub, nil
 }
-
 
 /*
 LoadPublicKey parses an RSA public key from a PEM formatted file at the passed
@@ -50,83 +49,82 @@ path into the Key object on which it was called.  It returns an error if the
 file at path does not exist or is not a PEM formatted RSA public key.
 */
 func (k *Key) LoadPublicKey(path string) error {
-  keyFile, err := os.Open(path)
-  defer keyFile.Close()
-  if err != nil {
-    return err
-  }
+	keyFile, err := os.Open(path)
+	defer keyFile.Close()
+	if err != nil {
+		return err
+	}
 
-  // Read key bytes and decode PEM
-  keyBytes, err := ioutil.ReadAll(keyFile)
-  if err != nil {
-    return err
-  }
+	// Read key bytes and decode PEM
+	keyBytes, err := ioutil.ReadAll(keyFile)
+	if err != nil {
+		return err
+	}
 
-  // We only parse to see if this is indeed a pem formatted rsa public key,
-  // but don't use the returned *rsa.PublicKey. Instead, we continue with
-  // the original keyBytes from above.
-  _, err = ParseRSAPublicKeyFromPEM(keyBytes)
-  if err != nil {
-    return err
-  }
+	// We only parse to see if this is indeed a pem formatted rsa public key,
+	// but don't use the returned *rsa.PublicKey. Instead, we continue with
+	// the original keyBytes from above.
+	_, err = ParseRSAPublicKeyFromPEM(keyBytes)
+	if err != nil {
+		return err
+	}
 
-  // Strip leading and trailing data from PEM file like securesystemslib does
-  // TODO: Should we instead use the parsed public key to reconstruct the PEM?
-  keyHeader := "-----BEGIN PUBLIC KEY-----"
-  keyFooter := "-----END PUBLIC KEY-----"
-  keyStart := strings.Index(string(keyBytes), keyHeader)
-  keyEnd := strings.Index(string(keyBytes), keyFooter) + len(keyFooter)
+	// Strip leading and trailing data from PEM file like securesystemslib does
+	// TODO: Should we instead use the parsed public key to reconstruct the PEM?
+	keyHeader := "-----BEGIN PUBLIC KEY-----"
+	keyFooter := "-----END PUBLIC KEY-----"
+	keyStart := strings.Index(string(keyBytes), keyHeader)
+	keyEnd := strings.Index(string(keyBytes), keyFooter) + len(keyFooter)
 
-  // Fail if header and footer are not present
-  // TODO: Is this necessary? ParseRSAPublicKeyFromPEM should already
-  // return an error if header and footer are not present
-  if keyStart == -1 || keyEnd == -1 {
-    return fmt.Errorf("No valid public rsa key found at '%s'", path)
-  }
-  keyBytesStripped := keyBytes[keyStart:keyEnd]
+	// Fail if header and footer are not present
+	// TODO: Is this necessary? ParseRSAPublicKeyFromPEM should already
+	// return an error if header and footer are not present
+	if keyStart == -1 || keyEnd == -1 {
+		return fmt.Errorf("No valid public rsa key found at '%s'", path)
+	}
+	keyBytesStripped := keyBytes[keyStart:keyEnd]
 
-  // Declare values for key
-  // TODO: Do not hardcode here, but define defaults elsewhere and add support
-  // for parametrization
-  keyType := "rsa"
-  scheme := "rsassa-pss-sha256"
-  keyIdHashAlgorithms := []string{"sha256", "sha512"}
+	// Declare values for key
+	// TODO: Do not hardcode here, but define defaults elsewhere and add support
+	// for parametrization
+	keyType := "rsa"
+	scheme := "rsassa-pss-sha256"
+	keyIdHashAlgorithms := []string{"sha256", "sha512"}
 
-  // Create partial key map used to create the keyid
-  // Unfortunately, we can't use the Key object because this also carries
-  // yet unwanted fields, such as KeyId and KeyVal.Private and therefore
-  // produces a different hash
-  var keyToBeHashed = map[string]interface{}{
-    "keytype": keyType,
-    "scheme": scheme,
-    "keyid_hash_algorithms": keyIdHashAlgorithms,
-    "keyval": map[string]string{
-      "public": string(keyBytesStripped),
-    },
-  }
+	// Create partial key map used to create the keyid
+	// Unfortunately, we can't use the Key object because this also carries
+	// yet unwanted fields, such as KeyId and KeyVal.Private and therefore
+	// produces a different hash
+	var keyToBeHashed = map[string]interface{}{
+		"keytype":               keyType,
+		"scheme":                scheme,
+		"keyid_hash_algorithms": keyIdHashAlgorithms,
+		"keyval": map[string]string{
+			"public": string(keyBytesStripped),
+		},
+	}
 
-  // Canonicalize key and get hex representation of hash
-  keyCanonical, err := encode_canonical(keyToBeHashed)
-  if err != nil {
-    return err
-  }
-  keyHashed := sha256.Sum256(keyCanonical)
+	// Canonicalize key and get hex representation of hash
+	keyCanonical, err := encode_canonical(keyToBeHashed)
+	if err != nil {
+		return err
+	}
+	keyHashed := sha256.Sum256(keyCanonical)
 
-  // Unmarshalling the canonicalized key into the Key object would seem natural
-  // Unfortunately, our mandated canonicalization function produces a byte
-  // slice that cannot be unmarshalled by Golang's json decoder, hence we have
-  // to manually assign the values
-  k.KeyType = keyType
-  k.KeyVal = KeyVal{
-      Public: string(keyBytesStripped),
-    }
-  k.Scheme = scheme
-  k.KeyIdHashAlgorithms = keyIdHashAlgorithms
-  k.KeyId = fmt.Sprintf("%x", keyHashed)
+	// Unmarshalling the canonicalized key into the Key object would seem natural
+	// Unfortunately, our mandated canonicalization function produces a byte
+	// slice that cannot be unmarshalled by Golang's json decoder, hence we have
+	// to manually assign the values
+	k.KeyType = keyType
+	k.KeyVal = KeyVal{
+		Public: string(keyBytesStripped),
+	}
+	k.Scheme = scheme
+	k.KeyIdHashAlgorithms = keyIdHashAlgorithms
+	k.KeyId = fmt.Sprintf("%x", keyHashed)
 
-  return nil
+	return nil
 }
-
 
 /*
 VerifySignature uses the passed Key to verify the passed Signature over the
@@ -134,29 +132,28 @@ passed data.  It returns an error if the key is not a valid RSA public key or
 if the signature is not valid for the data.
 */
 func VerifySignature(key Key, sig Signature, data []byte) error {
-  // Create rsa.PublicKey object from DER encoded public key string as
-  // found in the public part of the keyval part of a securesystemslib key dict
-  keyReader := strings.NewReader(key.KeyVal.Public)
-  pemBytes, err := ioutil.ReadAll(keyReader)
-  if err != nil {
-    return err
-  }
-  rsaPub, err := ParseRSAPublicKeyFromPEM(pemBytes)
-  if err != nil {
-    return err
-  }
+	// Create rsa.PublicKey object from DER encoded public key string as
+	// found in the public part of the keyval part of a securesystemslib key dict
+	keyReader := strings.NewReader(key.KeyVal.Public)
+	pemBytes, err := ioutil.ReadAll(keyReader)
+	if err != nil {
+		return err
+	}
+	rsaPub, err := ParseRSAPublicKeyFromPEM(pemBytes)
+	if err != nil {
+		return err
+	}
 
+	hashed := sha256.Sum256(data)
 
-  hashed := sha256.Sum256(data)
+	// Create hex bytes from the signature hex string
+	sigHex, _ := hex.DecodeString(sig.Sig)
 
-  // Create hex bytes from the signature hex string
-  sigHex, _ := hex.DecodeString(sig.Sig)
+	// SecSysLib uses a SaltLength of `hashes.SHA256().digest_size`, i.e. 32
+	if err := rsa.VerifyPSS(rsaPub, crypto.SHA256, hashed[:], sigHex,
+		&rsa.PSSOptions{SaltLength: sha256.Size, Hash: crypto.SHA256}); err != nil {
+		return err
+	}
 
-  // SecSysLib uses a SaltLength of `hashes.SHA256().digest_size`, i.e. 32
-  if err := rsa.VerifyPSS(rsaPub, crypto.SHA256, hashed[:], sigHex,
-    &rsa.PSSOptions{SaltLength: sha256.Size, Hash: crypto.SHA256}); err != nil {
-    return err
-  }
-
-  return nil
+	return nil
 }

--- a/in_toto/model.go
+++ b/in_toto/model.go
@@ -1,12 +1,11 @@
 package in_toto
 
 import (
-  "os"
-  "fmt"
-  "io/ioutil"
-  "encoding/json"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
 )
-
 
 /*
 KeyVal contains the actual values of a key, as opposed to key metadata such as
@@ -15,10 +14,9 @@ and private keys in PEM format stored as strings.  For public keys the Private
 field may be an empty string.
 */
 type KeyVal struct {
-  Private string `json:"private"`
-  Public string `json:"public"`
+	Private string `json:"private"`
+	Public  string `json:"public"`
 }
-
 
 /*
 Key represents a generic in-toto key that contains key metadata, such as an
@@ -26,13 +24,12 @@ identifier, supported hash algorithms to create the identifier, the key type
 and the supported signature scheme, and the actual key value.
 */
 type Key struct {
-  KeyId string `json:"keyid"`
-  KeyIdHashAlgorithms []string `json:"keyid_hash_algorithms"`
-  KeyType string `json:"keytype"`
-  KeyVal KeyVal `json:"keyval"`
-  Scheme string `json:"scheme"`
+	KeyId               string   `json:"keyid"`
+	KeyIdHashAlgorithms []string `json:"keyid_hash_algorithms"`
+	KeyType             string   `json:"keytype"`
+	KeyVal              KeyVal   `json:"keyval"`
+	Scheme              string   `json:"scheme"`
 }
-
 
 /*
 Signature represents a generic in-toto signature that contains the identifier
@@ -40,10 +37,9 @@ of the Key, which was used to create the signature and the signature data.  The
 used signature scheme is found in the corresponding Key.
 */
 type Signature struct {
-  KeyId string `json:"keyid"`
-  Sig string `json:"sig"`
+	KeyId string `json:"keyid"`
+	Sig   string `json:"sig"`
 }
-
 
 /*
 Link represents the evidence of a supply chain step performed by a functionary.
@@ -52,15 +48,14 @@ functionality for signing and signature verification, and reading from and
 writing to disk.
 */
 type Link struct {
-  Type string `json:"_type"`
-  Name string `json:"name"`
-  Materials map[string]interface{} `json:"materials"`
-  Products map[string]interface{} `json:"products"`
-  ByProducts map[string]interface{} `json:"byproducts"`
-  Command []string `json:"command"`
-  Environment map[string]interface{} `json:"environment"`
+	Type        string                 `json:"_type"`
+	Name        string                 `json:"name"`
+	Materials   map[string]interface{} `json:"materials"`
+	Products    map[string]interface{} `json:"products"`
+	ByProducts  map[string]interface{} `json:"byproducts"`
+	Command     []string               `json:"command"`
+	Environment map[string]interface{} `json:"environment"`
 }
-
 
 /*
 LinkNameFormat represents a format string used to create the filename for a
@@ -77,17 +72,15 @@ that are not signed, e.g.:
 const LinkNameFormat = "%s.%.8s.link"
 const LinkNameFormatShort = "%s.link"
 
-
 /*
 SupplyChainItem summarizes common fields of the two available supply chain
 item types, Inspection and Step.
 */
 type SupplyChainItem struct {
-  Name string  `json:"name"`
-  ExpectedMaterials [][]string `json:"expected_materials"`
-  ExpectedProducts [][]string `json:"expected_products"`
+	Name              string     `json:"name"`
+	ExpectedMaterials [][]string `json:"expected_materials"`
+	ExpectedProducts  [][]string `json:"expected_products"`
 }
-
 
 /*
 Inspection represents an in-toto supply chain inspection, whose command in the
@@ -97,11 +90,10 @@ constrained by the artifact rules in the inspection's ExpectedMaterials and
 ExpectedProducts fields.
 */
 type Inspection struct {
-  Type string `json:"_type"`
-  Run []string `json:"run"`
-  SupplyChainItem
+	Type string   `json:"_type"`
+	Run  []string `json:"run"`
+	SupplyChainItem
 }
-
 
 /*
 Step represents an in-toto step of the supply chain performed by a functionary.
@@ -112,13 +104,12 @@ by the step are constrained by the artifact rules in the step's
 ExpectedMaterials and ExpectedProducts fields.
 */
 type Step struct {
-  Type string `json:"_type"`
-  PubKeys []string `json:"pubkeys"`
-  ExpectedCommand []string `json:"expected_command"`
-  Threshold int `json:"threshold"`
-  SupplyChainItem
+	Type            string   `json:"_type"`
+	PubKeys         []string `json:"pubkeys"`
+	ExpectedCommand []string `json:"expected_command"`
+	Threshold       int      `json:"threshold"`
+	SupplyChainItem
 }
-
 
 /*
 Layout represents the definition of a software supply chain.  It lists the
@@ -130,14 +121,13 @@ contained in a generic Metablock object, which provides functionality for
 signing and signature verification, and reading from and writing to disk.
 */
 type Layout struct {
-  Type string `json:"_type"`
-  Steps []Step `json:"steps"`
-  Inspect []Inspection `json:"inspect"`
-  Keys map[string]Key `json:"keys"`
-  Expires string `json:"expires"`
-  Readme string `json:"readme"`
+	Type    string         `json:"_type"`
+	Steps   []Step         `json:"steps"`
+	Inspect []Inspection   `json:"inspect"`
+	Keys    map[string]Key `json:"keys"`
+	Expires string         `json:"expires"`
+	Readme  string         `json:"readme"`
 }
-
 
 // Go does not allow to pass `[]T` (slice with certain type) to a function
 // that accepts `[]interface{}` (slice with generic type)
@@ -145,20 +135,19 @@ type Layout struct {
 // https://golang.org/doc/faq#convert_slice_of_interface
 // TODO: Is there a better way to do polymorphism for steps and inspections?
 func (l *Layout) StepsAsInterfaceSlice() []interface{} {
-  stepsI := make([]interface{}, len(l.Steps))
-  for i, v := range l.Steps {
-    stepsI[i] = v
-  }
-  return stepsI
+	stepsI := make([]interface{}, len(l.Steps))
+	for i, v := range l.Steps {
+		stepsI[i] = v
+	}
+	return stepsI
 }
 func (l *Layout) InspectAsInterfaceSlice() []interface{} {
-  inspectionsI := make([]interface{}, len(l.Inspect))
-  for i, v := range l.Inspect {
-    inspectionsI[i] = v
-  }
-  return inspectionsI
+	inspectionsI := make([]interface{}, len(l.Inspect))
+	for i, v := range l.Inspect {
+		inspectionsI[i] = v
+	}
+	return inspectionsI
 }
-
 
 /*
 Metablock is a generic container for signable in-toto objects such as Layout
@@ -167,20 +156,19 @@ contains corresponding signatures.  Metablock also provides functionality for
 signing and signature verification, and reading from and writing to disk.
 */
 type Metablock struct {
-  // NOTE: Whenever we want to access an attribute of `Signed` we have to
-  // perform type assertion, e.g. `metablock.Signed.(Layout).Keys`
-  // Maybe there is a better way to store either Layouts or Links in `Signed`?
-  // The notary folks seem to have separate container structs:
-  // https://github.com/theupdateframework/notary/blob/master/tuf/data/root.go#L10-L14
-  // https://github.com/theupdateframework/notary/blob/master/tuf/data/targets.go#L13-L17
-  // I implemented it this way, because there will be several functions that
-  // receive or return a Metablock, where the type of Signed has to be inferred
-  // on runtime, e.g. when iterating over links for a layout, and a link can
-  // turn out to be a layout (sublayout)
-  Signed interface{} `json:"signed"`
-  Signatures []Signature `json:"signatures"`
+	// NOTE: Whenever we want to access an attribute of `Signed` we have to
+	// perform type assertion, e.g. `metablock.Signed.(Layout).Keys`
+	// Maybe there is a better way to store either Layouts or Links in `Signed`?
+	// The notary folks seem to have separate container structs:
+	// https://github.com/theupdateframework/notary/blob/master/tuf/data/root.go#L10-L14
+	// https://github.com/theupdateframework/notary/blob/master/tuf/data/targets.go#L13-L17
+	// I implemented it this way, because there will be several functions that
+	// receive or return a Metablock, where the type of Signed has to be inferred
+	// on runtime, e.g. when iterating over links for a layout, and a link can
+	// turn out to be a layout (sublayout)
+	Signed     interface{} `json:"signed"`
+	Signatures []Signature `json:"signatures"`
 }
-
 
 /*
 Load parses JSON formatted metadata at the passed path into the Metablock
@@ -188,83 +176,81 @@ object on which it was called.  It returns an error if it cannot parse
 a valid JSON formatted Metablock that contains a Link or Layout.
 */
 func (mb *Metablock) Load(path string) error {
-  // Open file and close before returning
-  jsonFile, err := os.Open(path)
-  defer jsonFile.Close()
-  if err != nil {
-    return err
-  }
+	// Open file and close before returning
+	jsonFile, err := os.Open(path)
+	defer jsonFile.Close()
+	if err != nil {
+		return err
+	}
 
-  // Read entire file
-  jsonBytes, err := ioutil.ReadAll(jsonFile)
-  if err != nil {
-    return err
-  }
+	// Read entire file
+	jsonBytes, err := ioutil.ReadAll(jsonFile)
+	if err != nil {
+		return err
+	}
 
-  // Unmarshal JSON into a map of raw messages (signed and signatures)
-  // We can't fully unmarshal immediately, because we need to inspect the
-  // type (link or layout) to decide which data structure to use
-  var rawMb map[string]*json.RawMessage
-  if err := json.Unmarshal(jsonBytes, &rawMb); err != nil {
-    return err
-  }
+	// Unmarshal JSON into a map of raw messages (signed and signatures)
+	// We can't fully unmarshal immediately, because we need to inspect the
+	// type (link or layout) to decide which data structure to use
+	var rawMb map[string]*json.RawMessage
+	if err := json.Unmarshal(jsonBytes, &rawMb); err != nil {
+		return err
+	}
 
-  // Fully unmarshal signatures part
-  if err := json.Unmarshal(*rawMb["signatures"], &mb.Signatures); err != nil {
-    return err
-  }
+	// Fully unmarshal signatures part
+	if err := json.Unmarshal(*rawMb["signatures"], &mb.Signatures); err != nil {
+		return err
+	}
 
-  // Temporarily copy signed to opaque map to inspect the `_type` of signed
-  // and create link or layout accordingly
-  var signed map[string]interface{}
-  if err := json.Unmarshal(*rawMb["signed"], &signed); err != nil {
-    return err
-  }
+	// Temporarily copy signed to opaque map to inspect the `_type` of signed
+	// and create link or layout accordingly
+	var signed map[string]interface{}
+	if err := json.Unmarshal(*rawMb["signed"], &signed); err != nil {
+		return err
+	}
 
-  if signed["_type"] == "link" {
-    var link Link
-    if err := json.Unmarshal(*rawMb["signed"], &link); err != nil {
-    return err
-  }
-    mb.Signed = link
+	if signed["_type"] == "link" {
+		var link Link
+		if err := json.Unmarshal(*rawMb["signed"], &link); err != nil {
+			return err
+		}
+		mb.Signed = link
 
-  } else if signed["_type"] == "layout" {
-    var layout Layout
-    if err := json.Unmarshal(*rawMb["signed"], &layout); err != nil {
-    return err
-  }
-    mb.Signed = layout
+	} else if signed["_type"] == "layout" {
+		var layout Layout
+		if err := json.Unmarshal(*rawMb["signed"], &layout); err != nil {
+			return err
+		}
+		mb.Signed = layout
 
-  } else {
-    return fmt.Errorf(`The '_type' field of the 'signed' part of a metadata
+	} else {
+		return fmt.Errorf(`The '_type' field of the 'signed' part of a metadata
         file must be one of 'link' or 'layout'`)
-  }
+	}
 
-  return nil
+	return nil
 }
-
 
 /*
 Dump JSON serializes and writes the Metablock on which it was called to the
 passed path.  It returns an error if JSON serialization or writing fails.
 */
 func (mb *Metablock) Dump(path string) error {
-  // JSON encode Metablock formatted with newlines and indentation
-  // TODO: parametrize format
-  jsonBytes, err := json.MarshalIndent(mb, "", "  ")
-  if err != nil {
-    return err
-  }
+	// JSON encode Metablock formatted with newlines and indentation
+	// TODO: parametrize format
+	jsonBytes, err := json.MarshalIndent(mb, "", "  ")
+	if err != nil {
+		return err
+	}
 
-  // Write JSON bytes to the passed path with permissions (-rw-r--r--)
-  err = ioutil.WriteFile(path, jsonBytes, 0644)
-  if err != nil {
-    return err
-  }
+	// Write JSON bytes to the passed path with permissions (-rw-r--r--)
+	err = ioutil.WriteFile(path, jsonBytes, 0644)
+	if err != nil {
+		return err
+	}
 
-  return nil
+	return nil
 }
-
 
 /*
 GetSignableRepresentation returns the canonical JSON representation of the
@@ -272,9 +258,8 @@ Signed field of the Metablock on which it was called.  If canonicalization
 fails the first return value is nil and the second return value is the error.
 */
 func (mb *Metablock) GetSignableRepresentation() ([]byte, error) {
-  return encode_canonical(mb.Signed)
+	return encode_canonical(mb.Signed)
 }
-
 
 /*
 VerifySignature verifies the first signature, corresponding to the passed Key,
@@ -284,25 +269,25 @@ the passed Key, the object in Signed cannot be canonicalized, or the Signature
 is invalid.
 */
 func (mb *Metablock) VerifySignature(key Key) error {
-  var sig Signature
-  for _, s := range mb.Signatures {
-    if s.KeyId == key.KeyId {
-      sig = s
-      break
-    }
-  }
+	var sig Signature
+	for _, s := range mb.Signatures {
+		if s.KeyId == key.KeyId {
+			sig = s
+			break
+		}
+	}
 
-  if sig == (Signature{}) {
-    return fmt.Errorf("No signature found for key '%s'", key.KeyId)
-  }
+	if sig == (Signature{}) {
+		return fmt.Errorf("No signature found for key '%s'", key.KeyId)
+	}
 
-  dataCanonical, err := mb.GetSignableRepresentation()
-  if err != nil {
-    return err
-  }
+	dataCanonical, err := mb.GetSignableRepresentation()
+	if err != nil {
+		return err
+	}
 
-  if err := VerifySignature(key, sig, dataCanonical); err != nil {
-    return err
-  }
-  return nil
+	if err := VerifySignature(key, sig, dataCanonical); err != nil {
+		return err
+	}
+	return nil
 }

--- a/in_toto/rulelib.go
+++ b/in_toto/rulelib.go
@@ -1,20 +1,19 @@
 package in_toto
 
 import (
-  "fmt"
-  "strings"
-  )
+	"fmt"
+	"strings"
+)
 
 // An error message issued in UnpackRule if it receives a malformed rule.
 var errorMsg string = "Wrong rule format, available formats are:\n" +
-  "\tMATCH <pattern> [IN <source-path-prefix>] WITH (MATERIALS|PRODUCTS)" +
-      " [IN <destination-path-prefix>] FROM <step>,\n" +
-  "\tCREATE <pattern>,\n" +
-  "\tDELETE <pattern>,\n" +
-  "\tMODIFY <pattern>,\n" +
-  "\tALLOW <pattern>,\n" +
-  "\tDISALLOW <pattern>\n\n"
-
+	"\tMATCH <pattern> [IN <source-path-prefix>] WITH (MATERIALS|PRODUCTS)" +
+	" [IN <destination-path-prefix>] FROM <step>,\n" +
+	"\tCREATE <pattern>,\n" +
+	"\tDELETE <pattern>,\n" +
+	"\tMODIFY <pattern>,\n" +
+	"\tALLOW <pattern>,\n" +
+	"\tDISALLOW <pattern>\n\n"
 
 /*
 UnpackRule parses the passed rule and extracts and returns the information
@@ -43,90 +42,88 @@ If the rule does not match any of the available formats the first return value
 is nil and the second return value is the error.
 */
 func UnpackRule(rule []string) (map[string]string, error) {
-  // Cache rule len
-  ruleLen := len(rule)
+	// Cache rule len
+	ruleLen := len(rule)
 
-  // Create all lower rule copy to case-insensitively parse out tokens whose
-  // position we don't know yet. We keep the original rule to retain the
-  // non-token elements' case.
-  ruleLower := make([]string, ruleLen)
-  for i, val := range rule {
-    ruleLower[i] = strings.ToLower(val)
-  }
+	// Create all lower rule copy to case-insensitively parse out tokens whose
+	// position we don't know yet. We keep the original rule to retain the
+	// non-token elements' case.
+	ruleLower := make([]string, ruleLen)
+	for i, val := range rule {
+		ruleLower[i] = strings.ToLower(val)
+	}
 
-  switch ruleLower[0] {
-    case "create", "modify", "delete", "allow", "disallow":
-        if ruleLen != 2 {
-          return nil,
-              fmt.Errorf("%s Got:\n\t %s", errorMsg, rule)
-        }
+	switch ruleLower[0] {
+	case "create", "modify", "delete", "allow", "disallow":
+		if ruleLen != 2 {
+			return nil,
+				fmt.Errorf("%s Got:\n\t %s", errorMsg, rule)
+		}
 
-        return map[string]string {
-          "type": ruleLower[0],
-          "pattern": rule[1],
-        }, nil
+		return map[string]string{
+			"type":    ruleLower[0],
+			"pattern": rule[1],
+		}, nil
 
-    case "match":
-      var srcPrefix string
-      var dstType string
-      var dstPrefix string
-      var dstName string
+	case "match":
+		var srcPrefix string
+		var dstType string
+		var dstPrefix string
+		var dstName string
 
-      // MATCH <pattern> IN <source-path-prefix> WITH (MATERIALS|PRODUCTS) \
-      // IN <destination-path-prefix> FROM <step>
-      if ruleLen == 10 && ruleLower[2] == "in" &&
-          ruleLower[4] == "with" && ruleLower[6] == "in" &&
-          ruleLower[8] == "from" {
-        srcPrefix = rule[3]
-        dstType = ruleLower[5]
-        dstPrefix = rule[7]
-        dstName = rule[9]
+		// MATCH <pattern> IN <source-path-prefix> WITH (MATERIALS|PRODUCTS) \
+		// IN <destination-path-prefix> FROM <step>
+		if ruleLen == 10 && ruleLower[2] == "in" &&
+			ruleLower[4] == "with" && ruleLower[6] == "in" &&
+			ruleLower[8] == "from" {
+			srcPrefix = rule[3]
+			dstType = ruleLower[5]
+			dstPrefix = rule[7]
+			dstName = rule[9]
 
+			// MATCH <pattern> IN <source-path-prefix> WITH (MATERIALS|PRODUCTS) \
+			// FROM <step>
+		} else if ruleLen == 8 && ruleLower[2] == "in" &&
+			ruleLower[4] == "with" && ruleLower[6] == "from" {
+			srcPrefix = rule[3]
+			dstType = ruleLower[5]
+			dstPrefix = ""
+			dstName = rule[7]
 
-      // MATCH <pattern> IN <source-path-prefix> WITH (MATERIALS|PRODUCTS) \
-      // FROM <step>
-      } else if ruleLen == 8 && ruleLower[2] == "in" &&
-          ruleLower[4] == "with" && ruleLower[6] == "from" {
-        srcPrefix = rule[3]
-        dstType = ruleLower[5]
-        dstPrefix = ""
-        dstName = rule[7]
+			// MATCH <pattern> WITH (MATERIALS|PRODUCTS) IN <destination-path-prefix>
+			// FROM <step>
+		} else if ruleLen == 8 && ruleLower[2] == "with" &&
+			ruleLower[4] == "in" && ruleLower[6] == "from" {
+			srcPrefix = ""
+			dstType = ruleLower[3]
+			dstPrefix = rule[5]
+			dstName = rule[7]
 
-      // MATCH <pattern> WITH (MATERIALS|PRODUCTS) IN <destination-path-prefix>
-      // FROM <step>
-      } else if ruleLen == 8 && ruleLower[2] == "with" &&
-          ruleLower[4] == "in" && ruleLower[6] == "from" {
-        srcPrefix = ""
-        dstType = ruleLower[3]
-        dstPrefix = rule[5]
-        dstName = rule[7]
+			// MATCH <pattern> WITH (MATERIALS|PRODUCTS) FROM <step>
+		} else if ruleLen == 6 && ruleLower[2] == "with" &&
+			ruleLower[4] == "from" {
+			srcPrefix = ""
+			dstType = ruleLower[3]
+			dstPrefix = ""
+			dstName = rule[5]
 
-      // MATCH <pattern> WITH (MATERIALS|PRODUCTS) FROM <step>
-      } else if ruleLen == 6 && ruleLower[2] == "with" &&
-          ruleLower[4] == "from" {
-        srcPrefix = ""
-        dstType = ruleLower[3]
-        dstPrefix = ""
-        dstName = rule[5]
+		} else {
+			return nil,
+				fmt.Errorf("%s Got:\n\t %s", errorMsg, rule)
 
-      } else {
-        return nil,
-            fmt.Errorf("%s Got:\n\t %s", errorMsg, rule)
+		}
 
-      }
+		return map[string]string{
+			"type":      ruleLower[0],
+			"pattern":   rule[1],
+			"srcPrefix": srcPrefix,
+			"dstPrefix": dstPrefix,
+			"dstType":   dstType,
+			"dstName":   dstName,
+		}, nil
 
-      return map[string]string{
-        "type": ruleLower[0],
-        "pattern": rule[1],
-        "srcPrefix": srcPrefix,
-        "dstPrefix": dstPrefix,
-        "dstType": dstType,
-        "dstName": dstName,
-      }, nil
-
-
-    default:
-      return nil,
-          fmt.Errorf("%s Got:\n\t %s", errorMsg, rule)
-  }
+	default:
+		return nil,
+			fmt.Errorf("%s Got:\n\t %s", errorMsg, rule)
+	}
 }

--- a/in_toto/rulelib_test.go
+++ b/in_toto/rulelib_test.go
@@ -1,80 +1,80 @@
 package in_toto
 
 import (
-  "testing"
-  )
+	"testing"
+)
 
 func TestUnpackValidRules(t *testing.T) {
 
-  // A list of valid rules (lists)
-  // Each will be passed to rulelib.UnpackRule below
-  rules := [][]string {
-    []string{"CREATE", "foo"},
-    []string{"DELETE", "foo"},
-    []string{"MODIFY", "foo"},
-    []string{"ALLOW", "foo"},
-    []string{"DISALLOW", "foo"},
-    []string {"MATCH", "foo", "IN", "source-path", "WITH", "PRODUCTS", "IN",
-        "dest-path", "FROM", "step-name"},
-    []string {"MATCH", "foo", "IN", "source-path", "WITH", "MATERIALS",
-        "FROM", "step-name"},
-    []string {"MATCH", "foo", "WITH", "PRODUCTS", "IN", "dest-path",
-        "FROM", "step-name"},
-    []string {"MATCH", "foo", "WITH", "MATERIALS", "FROM", "step-name"},
-  }
+	// A list of valid rules (lists)
+	// Each will be passed to rulelib.UnpackRule below
+	rules := [][]string{
+		[]string{"CREATE", "foo"},
+		[]string{"DELETE", "foo"},
+		[]string{"MODIFY", "foo"},
+		[]string{"ALLOW", "foo"},
+		[]string{"DISALLOW", "foo"},
+		[]string{"MATCH", "foo", "IN", "source-path", "WITH", "PRODUCTS", "IN",
+			"dest-path", "FROM", "step-name"},
+		[]string{"MATCH", "foo", "IN", "source-path", "WITH", "MATERIALS",
+			"FROM", "step-name"},
+		[]string{"MATCH", "foo", "WITH", "PRODUCTS", "IN", "dest-path",
+			"FROM", "step-name"},
+		[]string{"MATCH", "foo", "WITH", "MATERIALS", "FROM", "step-name"},
+	}
 
-  // These are the expected results from rulelib.UnpackRule for above rules
-  // (associated by index)
-  expectedRuleMaps := []map[string]string {
-     map[string]string{"type": "create", "pattern": "foo"},
-     map[string]string{"type": "delete", "pattern": "foo"},
-     map[string]string{"type": "modify", "pattern": "foo"},
-     map[string]string{"type": "allow", "pattern": "foo"},
-     map[string]string{"type": "disallow", "pattern": "foo"},
-    map[string]string{"type": "match", "pattern": "foo",
-        "srcPrefix": "source-path", "dstPrefix": "dest-path",
-        "dstType": "products" , "dstName": "step-name"},
-    map[string]string{"type": "match", "pattern": "foo",
-        "srcPrefix": "source-path", "dstPrefix": "",
-        "dstType": "materials" , "dstName": "step-name"},
-    map[string]string{"type": "match", "pattern": "foo",
-        "srcPrefix": "", "dstPrefix": "dest-path",
-        "dstType": "products" , "dstName": "step-name"},
-    map[string]string{"type": "match", "pattern": "foo",
-        "srcPrefix": "", "dstPrefix": "",
-        "dstType": "materials" , "dstName": "step-name"},
-  }
+	// These are the expected results from rulelib.UnpackRule for above rules
+	// (associated by index)
+	expectedRuleMaps := []map[string]string{
+		map[string]string{"type": "create", "pattern": "foo"},
+		map[string]string{"type": "delete", "pattern": "foo"},
+		map[string]string{"type": "modify", "pattern": "foo"},
+		map[string]string{"type": "allow", "pattern": "foo"},
+		map[string]string{"type": "disallow", "pattern": "foo"},
+		map[string]string{"type": "match", "pattern": "foo",
+			"srcPrefix": "source-path", "dstPrefix": "dest-path",
+			"dstType": "products", "dstName": "step-name"},
+		map[string]string{"type": "match", "pattern": "foo",
+			"srcPrefix": "source-path", "dstPrefix": "",
+			"dstType": "materials", "dstName": "step-name"},
+		map[string]string{"type": "match", "pattern": "foo",
+			"srcPrefix": "", "dstPrefix": "dest-path",
+			"dstType": "products", "dstName": "step-name"},
+		map[string]string{"type": "match", "pattern": "foo",
+			"srcPrefix": "", "dstPrefix": "",
+			"dstType": "materials", "dstName": "step-name"},
+	}
 
-  for i, rule := range rules {
-    returnedRuleMap, err := UnpackRule(rule)
-    if err != nil {
-      t.Error(err)
-    }
+	for i, rule := range rules {
+		returnedRuleMap, err := UnpackRule(rule)
+		if err != nil {
+			t.Error(err)
+		}
 
-    for _, key := range []string{"type", "pattern", "srcPrefix", "dstPrefix",
-        "dstName", "dstType"} {
-      if returnedRuleMap[key] != expectedRuleMaps[i][key] {
-        t.Errorf("Invalid '%s' in unpacked rule '%s', should be '%s', got" +
-              " '%s'", key, rule, expectedRuleMaps[i][key],
-              returnedRuleMap[key])
-      }
-    }
-  }
+		for _, key := range []string{"type", "pattern", "srcPrefix", "dstPrefix",
+			"dstName", "dstType"} {
+			if returnedRuleMap[key] != expectedRuleMaps[i][key] {
+				t.Errorf("Invalid '%s' in unpacked rule '%s', should be '%s', got"+
+					" '%s'", key, rule, expectedRuleMaps[i][key],
+					returnedRuleMap[key])
+			}
+		}
+	}
 }
 
 func TestUnpackInvalidRules(t *testing.T) {
-  rules := [][]string {
-    []string{"CREATE", "foo", "too-long"},
-    []string{"SUBVERT", "foo"},
-    []string{"MODIFY"},
-    []string {"MATCH", "foo", "too-many-patterns", "IN", "source-path", "WITH",
-      "PRODUCTS", "IN", "dest-path", "FROM", "step-name"},
-    []string {"MATCH", "foo", "WITH", "GUMMY", "BEARS"},
-  }
-  for _, rule := range rules {
-    if _, err := UnpackRule(rule); err == nil {
-      t.Errorf("Invalid rule %s should return error from UnpackRule.", rule)
-    }
-  }
+	rules := [][]string{
+		[]string{"CREATE", "foo", "too-long"},
+		[]string{"SUBVERT", "foo"},
+		[]string{"MODIFY"},
+		[]string{"MATCH", "foo", "too-many-patterns", "IN", "source-path", "WITH",
+			"PRODUCTS", "IN", "dest-path", "FROM", "step-name"},
+		[]string{"MATCH", "foo", "WITH", "GUMMY", "BEARS"},
+	}
+	for _, rule := range rules {
+		if _, err := UnpackRule(rule); err == nil {
+			t.Errorf("Invalid rule %s should return error from UnpackRule.", rule)
+		}
+	}
 
 }

--- a/in_toto/runlib.go
+++ b/in_toto/runlib.go
@@ -1,15 +1,14 @@
 package in_toto
 
 import (
-  "fmt"
-  "os"
-  "os/exec"
-  "syscall"
-  "io/ioutil"
-  "path/filepath"
-  "crypto/sha256"
+	"crypto/sha256"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
 )
-
 
 /*
 RecordArtifact reads and hashes the contents of the file at the passed path
@@ -23,21 +22,20 @@ If reading the file fails, the first return value is nil and the second return
 value is the error.
 */
 func RecordArtifact(path string) (map[string]interface{}, error) {
-  // Read file from passed path
-  content, err := ioutil.ReadFile(path)
-  if err != nil {
-    return nil, err
-  }
+	// Read file from passed path
+	content, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
 
-  // Create its sha 256 hash (currently we only support sha256 here)
-  hashed := sha256.Sum256(content)
+	// Create its sha 256 hash (currently we only support sha256 here)
+	hashed := sha256.Sum256(content)
 
-  // Return it in a format that is conformant with link metadata artifacts
-  return map[string]interface{} {
-    "sha256" : fmt.Sprintf("%x", hashed),
-  }, nil
+	// Return it in a format that is conformant with link metadata artifacts
+	return map[string]interface{}{
+		"sha256": fmt.Sprintf("%x", hashed),
+	}, nil
 }
-
 
 /*
 RecordArtifacts walks through the passed slice of paths, traversing
@@ -56,58 +54,56 @@ If recording an artifact fails the first return value is nil and the second
 return value is the error.
 */
 func RecordArtifacts(paths []string) (map[string]interface{}, error) {
-  artifacts := make(map[string]interface{})
-  // NOTE: Walk cannot follow symlinks
-  for _, path := range paths {
-    err := filepath.Walk(path,
-        func(path string, info os.FileInfo, err error) error {
-      // Don't hash directories
-      if info.IsDir() {
-        return nil
-      }
-      artifact, err := RecordArtifact(path)
-      if err != nil {
-        return err
-      }
-      artifacts[path] = artifact
-      return nil
-    })
-    if err != nil {
-      return nil, err
-    }
-  }
+	artifacts := make(map[string]interface{})
+	// NOTE: Walk cannot follow symlinks
+	for _, path := range paths {
+		err := filepath.Walk(path,
+			func(path string, info os.FileInfo, err error) error {
+				// Don't hash directories
+				if info.IsDir() {
+					return nil
+				}
+				artifact, err := RecordArtifact(path)
+				if err != nil {
+					return err
+				}
+				artifacts[path] = artifact
+				return nil
+			})
+		if err != nil {
+			return nil, err
+		}
+	}
 
-  return artifacts, nil
+	return artifacts, nil
 }
-
 
 /*
 WaitErrToExitCode converts an error returned by Cmd.wait() to an exit code.  It
 returns -1 if no exit code can be inferred.
 */
 func WaitErrToExitCode(err error) int {
-  // If there's no exit code, we return -1
-  retVal := -1
+	// If there's no exit code, we return -1
+	retVal := -1
 
-  // See https://stackoverflow.com/questions/10385551/get-exit-code-go
-  if err != nil {
-    if exiterr, ok := err.(*exec.ExitError); ok {
-      // The program has exited with an exit code != 0
-      // This works on both Unix and Windows. Although package
-      // syscall is generally platform dependent, WaitStatus is
-      // defined for both Unix and Windows and in both cases has
-      // an ExitStatus() method with the same signature.
-      if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
-        retVal = status.ExitStatus()
-      }
-    }
-  } else {
-    retVal = 0
-  }
+	// See https://stackoverflow.com/questions/10385551/get-exit-code-go
+	if err != nil {
+		if exiterr, ok := err.(*exec.ExitError); ok {
+			// The program has exited with an exit code != 0
+			// This works on both Unix and Windows. Although package
+			// syscall is generally platform dependent, WaitStatus is
+			// defined for both Unix and Windows and in both cases has
+			// an ExitStatus() method with the same signature.
+			if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
+				retVal = status.ExitStatus()
+			}
+		}
+	} else {
+		retVal = 0
+	}
 
-  return retVal
+	return retVal
 }
-
 
 /*
 RunCommand executes the passed command in a subprocess.  The first element of
@@ -125,33 +121,32 @@ command execution.
 */
 func RunCommand(cmdArgs []string) (map[string]interface{}, error) {
 
-  cmd := exec.Command(cmdArgs[0], cmdArgs[1:]...)
-  stderrPipe, err := cmd.StderrPipe()
-  if err != nil {
-    return nil, err
-  }
-  stdoutPipe, err := cmd.StdoutPipe()
-  if err != nil {
-    return nil, err
-  }
+	cmd := exec.Command(cmdArgs[0], cmdArgs[1:]...)
+	stderrPipe, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, err
+	}
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
 
-  if err := cmd.Start(); err != nil {
-    return nil, err
-  }
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
 
-  // TODO: duplicate stdout, stderr
-  stdout, _ := ioutil.ReadAll(stdoutPipe)
-  stderr, _ := ioutil.ReadAll(stderrPipe)
+	// TODO: duplicate stdout, stderr
+	stdout, _ := ioutil.ReadAll(stdoutPipe)
+	stderr, _ := ioutil.ReadAll(stderrPipe)
 
-  retVal := WaitErrToExitCode(cmd.Wait())
+	retVal := WaitErrToExitCode(cmd.Wait())
 
-  return map[string]interface{}{
-      "return-value": retVal,
-      "stdout": stdout,
-      "stderr": stderr,
-    }, nil
+	return map[string]interface{}{
+		"return-value": retVal,
+		"stdout":       stdout,
+		"stderr":       stderr,
+	}, nil
 }
-
 
 /*
 InTotoRun executes commands, e.g. for software supply chain steps or
@@ -163,33 +158,33 @@ return value is nil and the second return value is the error.
 NOTE: Currently InTotoRun cannot be used to sign Link metadata.
 */
 func InTotoRun(name string, materialPaths []string, productPaths []string,
-    cmdArgs []string) (Metablock, error) {
-  var linkMb Metablock
-  materials, err := RecordArtifacts(materialPaths)
-  if err != nil {
-    return linkMb, err
-  }
+	cmdArgs []string) (Metablock, error) {
+	var linkMb Metablock
+	materials, err := RecordArtifacts(materialPaths)
+	if err != nil {
+		return linkMb, err
+	}
 
-  byProducts, err := RunCommand(cmdArgs)
-  if err != nil {
-    return linkMb, err
-  }
+	byProducts, err := RunCommand(cmdArgs)
+	if err != nil {
+		return linkMb, err
+	}
 
-  products, err := RecordArtifacts(productPaths)
-  if err != nil {
-    return linkMb, err
-  }
+	products, err := RecordArtifacts(productPaths)
+	if err != nil {
+		return linkMb, err
+	}
 
-  linkMb.Signatures = []Signature{}
-  linkMb.Signed = Link{
-      Type: "link",
-      Name: name,
-      Materials: materials,
-      Products: products,
-      ByProducts: byProducts,
-      Command: cmdArgs,
-      Environment: map[string]interface{}{},
-    }
+	linkMb.Signatures = []Signature{}
+	linkMb.Signed = Link{
+		Type:        "link",
+		Name:        name,
+		Materials:   materials,
+		Products:    products,
+		ByProducts:  byProducts,
+		Command:     cmdArgs,
+		Environment: map[string]interface{}{},
+	}
 
-  return linkMb, nil
+	return linkMb, nil
 }

--- a/in_toto/verifylib.go
+++ b/in_toto/verifylib.go
@@ -6,14 +6,13 @@ See https://github.com/in-toto/docs/blob/master/in-toto-spec.md
 package in_toto
 
 import (
-  "fmt"
-  "time"
-  "strings"
-  "reflect"
-  osPath "path"
-  "path/filepath"
+	"fmt"
+	osPath "path"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"time"
 )
-
 
 /*
 RunInspections iteratively executes the command in the Run field of all
@@ -32,73 +31,70 @@ non-zero exit code, the first return value is nil and the second return value
 is the error.
 */
 func RunInspections(layout Layout) (map[string]Metablock, error) {
-  inspectionMetadata := make(map[string]Metablock)
+	inspectionMetadata := make(map[string]Metablock)
 
-  for _, inspection := range layout.Inspect {
+	for _, inspection := range layout.Inspect {
 
-    linkMb, err := InTotoRun(inspection.Name, []string{"."}, []string{"."},
-        inspection.Run)
-    if err != nil {
-      return nil, err
-    }
+		linkMb, err := InTotoRun(inspection.Name, []string{"."}, []string{"."},
+			inspection.Run)
+		if err != nil {
+			return nil, err
+		}
 
-    retVal := linkMb.Signed.(Link).ByProducts["return-value"]
-    if retVal != 0 {
-      return nil, fmt.Errorf("Inspection command '%s' of inspection '%s'" +
-          " returned a non-zero value: %d", inspection.Run, inspection.Name,
-          retVal)
-    }
+		retVal := linkMb.Signed.(Link).ByProducts["return-value"]
+		if retVal != 0 {
+			return nil, fmt.Errorf("Inspection command '%s' of inspection '%s'"+
+				" returned a non-zero value: %d", inspection.Run, inspection.Name,
+				retVal)
+		}
 
-    // Dump inspection link to cwd using the short link name format
-    linkName := fmt.Sprintf(LinkNameFormatShort, inspection.Name)
-    linkMb.Dump(linkName)
+		// Dump inspection link to cwd using the short link name format
+		linkName := fmt.Sprintf(LinkNameFormatShort, inspection.Name)
+		linkMb.Dump(linkName)
 
-    inspectionMetadata[inspection.Name] = linkMb
-  }
-  return inspectionMetadata, nil
+		inspectionMetadata[inspection.Name] = linkMb
+	}
+	return inspectionMetadata, nil
 }
-
 
 // Subtract is a helper function that performs set subtraction
 // TODO: This function has O(n**2), consider using maps (in linear-time)
 // https://siongui.github.io/2018/03/14/go-set-difference-of-two-arrays/, or
 // find a proper set library.
 func Subtract(a []string, b []string) []string {
-  var result []string
-  for _, valA := range a {
-    valInB := false
-    for _, valB := range b {
-      if valA == valB {
-        valInB = true
-        break
-      }
-    }
-    if !valInB {
-      result = append(result, valA)
-    }
-  }
-  return result
+	var result []string
+	for _, valA := range a {
+		valInB := false
+		for _, valB := range b {
+			if valA == valB {
+				valInB = true
+				break
+			}
+		}
+		if !valInB {
+			result = append(result, valA)
+		}
+	}
+	return result
 }
-
 
 // FnFilter is a helper function that mimics fnmatch.filter from the Python
 // standard library using Go Match from the path/filepath package.
-func FnFilter (pattern string, names []string) []string {
-  var namesFiltered []string
-  for _, name := range names {
-    matched, err := filepath.Match(pattern, name)
-    if err != nil {
-      // The pattern was invalid. We treat it as no match.
-      // TODO: Maybe we should inform the caller at least with a warning?
-      continue
-    }
-    if matched {
-      namesFiltered = append(namesFiltered, name)
-    }
-  }
-  return namesFiltered
+func FnFilter(pattern string, names []string) []string {
+	var namesFiltered []string
+	for _, name := range names {
+		matched, err := filepath.Match(pattern, name)
+		if err != nil {
+			// The pattern was invalid. We treat it as no match.
+			// TODO: Maybe we should inform the caller at least with a warning?
+			continue
+		}
+		if matched {
+			namesFiltered = append(namesFiltered, name)
+		}
+	}
+	return namesFiltered
 }
-
 
 /*
 VerifyArtifacts iteratively applies the material and product rules of the
@@ -117,161 +113,160 @@ DISALLOW rule to fail overall verification, if artifacts are left in the queue
 that should have been consumed by preceding rules.
 */
 func VerifyArtifacts(items []interface{},
-    itemsMetadata map[string]Metablock) error {
-  // Verify artifact rules for each item in the layout
-  for _, itemI := range items {
-    // The layout item (interface) must be a Link or an Inspection we are only
-    // interested in the name and the expected materials and products
-    var itemName string
-    var expected_materials [][]string
-    var expected_products [][]string
+	itemsMetadata map[string]Metablock) error {
+	// Verify artifact rules for each item in the layout
+	for _, itemI := range items {
+		// The layout item (interface) must be a Link or an Inspection we are only
+		// interested in the name and the expected materials and products
+		var itemName string
+		var expected_materials [][]string
+		var expected_products [][]string
 
-    switch item := itemI.(type) {
-      case Step:
-        itemName = item.Name
-        expected_materials = item.ExpectedMaterials
-        expected_products = item.ExpectedProducts
+		switch item := itemI.(type) {
+		case Step:
+			itemName = item.Name
+			expected_materials = item.ExpectedMaterials
+			expected_products = item.ExpectedProducts
 
-      case Inspection:
-        itemName = item.Name
-        expected_materials = item.ExpectedMaterials
-        expected_products = item.ExpectedProducts
+		case Inspection:
+			itemName = item.Name
+			expected_materials = item.ExpectedMaterials
+			expected_products = item.ExpectedProducts
 
-      default: // Something's wrong
-        return fmt.Errorf("VerifyArtifact received an item of invalid type," +
-            " elements of passed slice 'items' must be one of 'Step' or" +
-            " 'Inspection', got: '%s'", reflect.TypeOf(item))
-    }
-    srcLinkMb := itemsMetadata[itemName]
+		default: // Something's wrong
+			return fmt.Errorf("VerifyArtifact received an item of invalid type,"+
+				" elements of passed slice 'items' must be one of 'Step' or"+
+				" 'Inspection', got: '%s'", reflect.TypeOf(item))
+		}
+		srcLinkMb := itemsMetadata[itemName]
 
-    verificationDataList := []map[string]interface{}{
-      map[string]interface{}{
-        "rules": expected_materials,
-        "artifacts": srcLinkMb.Signed.(Link).Materials,
-      },
-      map[string]interface{}{
-        "rules": expected_products,
-        "artifacts": srcLinkMb.Signed.(Link).Products,
-      },
-    }
+		verificationDataList := []map[string]interface{}{
+			map[string]interface{}{
+				"rules":     expected_materials,
+				"artifacts": srcLinkMb.Signed.(Link).Materials,
+			},
+			map[string]interface{}{
+				"rules":     expected_products,
+				"artifacts": srcLinkMb.Signed.(Link).Products,
+			},
+		}
 
-    // Process all material rules using the corresponding materials
-    // and all product rules using the corresponding products
-    for _, verificationData := range verificationDataList {
+		// Process all material rules using the corresponding materials
+		// and all product rules using the corresponding products
+		for _, verificationData := range verificationDataList {
 
-      rules := verificationData["rules"].([][]string)
-      artifacts := verificationData["artifacts"].(map[string]interface{})
+			rules := verificationData["rules"].([][]string)
+			artifacts := verificationData["artifacts"].(map[string]interface{})
 
-      // Create a queue of artifact names (paths).  Each rule only operates on
-      // artifacts in that queue.  If a rule consumes an artifact (i.e. can be
-      // applied successfully), the artifact is removed from the queue.  By
-      // applying a DISALLOW rule eventually, verification may return an error,
-      // if the rule matches any artifacts in the queue that should have been
-      // consumed earlier.
-      var queue []string
-      for name, _ := range artifacts {
-        queue = append(queue, name)
-      }
+			// Create a queue of artifact names (paths).  Each rule only operates on
+			// artifacts in that queue.  If a rule consumes an artifact (i.e. can be
+			// applied successfully), the artifact is removed from the queue.  By
+			// applying a DISALLOW rule eventually, verification may return an error,
+			// if the rule matches any artifacts in the queue that should have been
+			// consumed earlier.
+			var queue []string
+			for name, _ := range artifacts {
+				queue = append(queue, name)
+			}
 
-      // Verify rules sequentially
-      for _, rule := range rules {
-        // Parse rule
-        ruleData, err := UnpackRule(rule)
-        if err != nil {
-          return err
-        }
+			// Verify rules sequentially
+			for _, rule := range rules {
+				// Parse rule
+				ruleData, err := UnpackRule(rule)
+				if err != nil {
+					return err
+				}
 
-        // Process rules according to rule type
-        // TODO: Currently we only process rules of type "match", "allow" or
-        // "disallow"
-        switch ruleData["type"] {
-          case "match":
-            // Get destination link metadata
-            dstLinkMb, exists := itemsMetadata[ruleData["dstName"]]
-            if !exists {
-              // Destination link does not exist, rule can't consume any
-              // artifacts
-              continue
-            }
+				// Process rules according to rule type
+				// TODO: Currently we only process rules of type "match", "allow" or
+				// "disallow"
+				switch ruleData["type"] {
+				case "match":
+					// Get destination link metadata
+					dstLinkMb, exists := itemsMetadata[ruleData["dstName"]]
+					if !exists {
+						// Destination link does not exist, rule can't consume any
+						// artifacts
+						continue
+					}
 
-            // Get artifacts from destination link metadata
-            var dstArtifacts map[string]interface{}
-            switch ruleData["dstType"] {
-              case "materials":
-                dstArtifacts = dstLinkMb.Signed.(Link).Materials
+					// Get artifacts from destination link metadata
+					var dstArtifacts map[string]interface{}
+					switch ruleData["dstType"] {
+					case "materials":
+						dstArtifacts = dstLinkMb.Signed.(Link).Materials
 
-              case "products":
-                dstArtifacts = dstLinkMb.Signed.(Link).Products
-            }
+					case "products":
+						dstArtifacts = dstLinkMb.Signed.(Link).Products
+					}
 
-            // Normalize optional source and destination prefixes, i.e. if
-            // there is a prefix, then add a trailing slash if not there yet
-            for _, prefix := range []string{"srcPrefix", "dstPrefix"} {
-              if ruleData[prefix] != "" &&
-                  ! strings.HasSuffix(ruleData[prefix], "/") {
-                ruleData[prefix] += "/"
-              }
-            }
-            // Iterate over queue and mark consumed artifacts
-            var consumed []string
-            for _, srcPath := range queue {
-              // Remove optional source prefix from source artifact path
-              // Noop if prefix is empty, or artifact does not have it
-              srcBasePath := strings.TrimPrefix(srcPath, ruleData["srcPrefix"])
+					// Normalize optional source and destination prefixes, i.e. if
+					// there is a prefix, then add a trailing slash if not there yet
+					for _, prefix := range []string{"srcPrefix", "dstPrefix"} {
+						if ruleData[prefix] != "" &&
+							!strings.HasSuffix(ruleData[prefix], "/") {
+							ruleData[prefix] += "/"
+						}
+					}
+					// Iterate over queue and mark consumed artifacts
+					var consumed []string
+					for _, srcPath := range queue {
+						// Remove optional source prefix from source artifact path
+						// Noop if prefix is empty, or artifact does not have it
+						srcBasePath := strings.TrimPrefix(srcPath, ruleData["srcPrefix"])
 
-              // Ignore artifacts not matched by rule pattern
-              matched, err := filepath.Match(ruleData["pattern"], srcBasePath)
-              if err != nil || !matched {
-                continue
-              }
+						// Ignore artifacts not matched by rule pattern
+						matched, err := filepath.Match(ruleData["pattern"], srcBasePath)
+						if err != nil || !matched {
+							continue
+						}
 
-              // Construct corresponding destination artifact path, i.e.
-              // an optional destination prefix plus the source base path
-              dstPath := osPath.Join(ruleData["dstPrefix"], srcBasePath)
+						// Construct corresponding destination artifact path, i.e.
+						// an optional destination prefix plus the source base path
+						dstPath := osPath.Join(ruleData["dstPrefix"], srcBasePath)
 
-              // Try to find the corresponding destination artifact
-              dstArtifact, exists := dstArtifacts[dstPath]
-              // Ignore artifacts without corresponding destination artifact
-              if !exists {
-                continue
-              }
+						// Try to find the corresponding destination artifact
+						dstArtifact, exists := dstArtifacts[dstPath]
+						// Ignore artifacts without corresponding destination artifact
+						if !exists {
+							continue
+						}
 
-              // Ignore artifact pairs with no matching hashes
-              if !reflect.DeepEqual(artifacts[srcPath], dstArtifact) {
-                continue
-              }
+						// Ignore artifact pairs with no matching hashes
+						if !reflect.DeepEqual(artifacts[srcPath], dstArtifact) {
+							continue
+						}
 
-              // Only if a source and destination artifact pair was found and
-              // their hashes are equal, will we mark the source artifact as
-              // successfully consumed, i.e. it will be removed from the queue
-              consumed = append(consumed, srcPath)
-            }
-            queue = Subtract(queue, consumed)
+						// Only if a source and destination artifact pair was found and
+						// their hashes are equal, will we mark the source artifact as
+						// successfully consumed, i.e. it will be removed from the queue
+						consumed = append(consumed, srcPath)
+					}
+					queue = Subtract(queue, consumed)
 
-          case "allow":
-            consumed := FnFilter(ruleData["pattern"], queue)
-            queue = Subtract(queue, consumed)
+				case "allow":
+					consumed := FnFilter(ruleData["pattern"], queue)
+					queue = Subtract(queue, consumed)
 
-          case "disallow":
-            disallowed := FnFilter(ruleData["pattern"], queue)
-            if len(disallowed) > 0 {
-              return fmt.Errorf("Artifact verification failed for %s '%s'." +
-                  " Artifact(s) %s disallowed by rule %s.",
-                  reflect.TypeOf(itemI), itemName, disallowed, rule)
-            }
+				case "disallow":
+					disallowed := FnFilter(ruleData["pattern"], queue)
+					if len(disallowed) > 0 {
+						return fmt.Errorf("Artifact verification failed for %s '%s'."+
+							" Artifact(s) %s disallowed by rule %s.",
+							reflect.TypeOf(itemI), itemName, disallowed, rule)
+					}
 
-          // TODO: Support create, modify, delete rules
-          default:
-              return fmt.Errorf("Cannot process artifact rule '%s'. We" +
-                  " don't support rules of type '%s'", rule,
-                  strings.ToUpper(ruleData["type"]))
-        }
-      }
-    }
-  }
-  return nil
+				// TODO: Support create, modify, delete rules
+				default:
+					return fmt.Errorf("Cannot process artifact rule '%s'. We"+
+						" don't support rules of type '%s'", rule,
+						strings.ToUpper(ruleData["type"]))
+				}
+			}
+		}
+	}
+	return nil
 }
-
 
 /*
 ReduceStepsMetadata merges for each step of the passed Layout all the passed
@@ -290,56 +285,55 @@ Products, the first return value is nil and the second return value is the
 error.
 */
 func ReduceStepsMetadata(layout Layout,
-    stepsMetadata map[string]map[string]Metablock) (map[string]Metablock,
-    error) {
-  stepsMetadataReduced := make(map[string]Metablock)
+	stepsMetadata map[string]map[string]Metablock) (map[string]Metablock,
+	error) {
+	stepsMetadataReduced := make(map[string]Metablock)
 
-  for _, step := range layout.Steps {
-    linksPerStep, ok := stepsMetadata[step.Name]
-    // We should never get here, layout verification must fail earlier
-    if !ok || len(linksPerStep) < 1 {
-      panic("Could not reduce metadata for step '" + step.Name +
-          "', no link metadata found.")
-    }
+	for _, step := range layout.Steps {
+		linksPerStep, ok := stepsMetadata[step.Name]
+		// We should never get here, layout verification must fail earlier
+		if !ok || len(linksPerStep) < 1 {
+			panic("Could not reduce metadata for step '" + step.Name +
+				"', no link metadata found.")
+		}
 
-    // Get the first link (could be any link) for the current step, which will
-    // serve as reference link for below comparisons
-    var referenceKeyID string
-    var referenceLinkMb Metablock
-    for keyID, linkMb := range linksPerStep {
-      referenceLinkMb = linkMb
-      referenceKeyID = keyID
-      break
-    }
+		// Get the first link (could be any link) for the current step, which will
+		// serve as reference link for below comparisons
+		var referenceKeyID string
+		var referenceLinkMb Metablock
+		for keyID, linkMb := range linksPerStep {
+			referenceLinkMb = linkMb
+			referenceKeyID = keyID
+			break
+		}
 
-    // Only one link, nothing to reduce, take the reference link
-    if len(linksPerStep) == 1 {
-      stepsMetadataReduced[step.Name] = referenceLinkMb
+		// Only one link, nothing to reduce, take the reference link
+		if len(linksPerStep) == 1 {
+			stepsMetadataReduced[step.Name] = referenceLinkMb
 
-    // Multiple links, reduce but first check
-    } else {
-      // Artifact maps must be equal for each type among all links
-      // TODO: What should we do if there are more links, than the
-      // threshold requires, but not all of them are equal? Right now we would
-      // also error.
-      for keyID, linkMb := range linksPerStep {
-        if !reflect.DeepEqual(linkMb.Signed.(Link).Materials,
-            referenceLinkMb.Signed.(Link).Materials) ||
-            !reflect.DeepEqual(linkMb.Signed.(Link).Products,
-            referenceLinkMb.Signed.(Link).Products) {
-          return nil, fmt.Errorf("Link '%s' and '%s' have different" +
-              " artifacts.",
-              fmt.Sprintf(LinkNameFormat, step.Name, referenceKeyID),
-              fmt.Sprintf(LinkNameFormat, step.Name, keyID))
-        }
-      }
-      // We haven't errored out, so we can reduce (i.e take the reference link)
-      stepsMetadataReduced[step.Name] = referenceLinkMb
-    }
-  }
-  return stepsMetadataReduced, nil
+			// Multiple links, reduce but first check
+		} else {
+			// Artifact maps must be equal for each type among all links
+			// TODO: What should we do if there are more links, than the
+			// threshold requires, but not all of them are equal? Right now we would
+			// also error.
+			for keyID, linkMb := range linksPerStep {
+				if !reflect.DeepEqual(linkMb.Signed.(Link).Materials,
+					referenceLinkMb.Signed.(Link).Materials) ||
+					!reflect.DeepEqual(linkMb.Signed.(Link).Products,
+						referenceLinkMb.Signed.(Link).Products) {
+					return nil, fmt.Errorf("Link '%s' and '%s' have different"+
+						" artifacts.",
+						fmt.Sprintf(LinkNameFormat, step.Name, referenceKeyID),
+						fmt.Sprintf(LinkNameFormat, step.Name, keyID))
+				}
+			}
+			// We haven't errored out, so we can reduce (i.e take the reference link)
+			stepsMetadataReduced[step.Name] = referenceLinkMb
+		}
+	}
+	return stepsMetadataReduced, nil
 }
-
 
 /*
 VerifyStepCommandAlignment (soft) verifies that for each step of the passed
@@ -348,29 +342,28 @@ command, as per the layout.  Soft verification means that, in case a command
 does not align, a warning is issued.
 */
 func VerifyStepCommandAlignment(layout Layout,
-    stepsMetadata map[string]map[string]Metablock) {
-  for _, step := range layout.Steps {
-    linksPerStep, ok := stepsMetadata[step.Name]
-    // We should never get here, layout verification must fail earlier
-    if !ok || len(linksPerStep) < 1 {
-      panic("Could not verify command alignment for step '" + step.Name +
-          "', no link metadata found.")
-    }
+	stepsMetadata map[string]map[string]Metablock) {
+	for _, step := range layout.Steps {
+		linksPerStep, ok := stepsMetadata[step.Name]
+		// We should never get here, layout verification must fail earlier
+		if !ok || len(linksPerStep) < 1 {
+			panic("Could not verify command alignment for step '" + step.Name +
+				"', no link metadata found.")
+		}
 
-    for signerKeyID, linkMb := range linksPerStep {
-      expectedCommandS := strings.Join(step.ExpectedCommand, " ")
-      executedCommandS := strings.Join(linkMb.Signed.(Link).Command, " ")
+		for signerKeyID, linkMb := range linksPerStep {
+			expectedCommandS := strings.Join(step.ExpectedCommand, " ")
+			executedCommandS := strings.Join(linkMb.Signed.(Link).Command, " ")
 
-      if expectedCommandS != executedCommandS {
-        linkName := fmt.Sprintf(LinkNameFormat, step.Name, signerKeyID)
-        fmt.Printf("WARNING: Expected command for step '%s' (%s) and command" +
-            " reported by '%s' (%s) differ.\n",
-            step.Name, expectedCommandS, linkName, executedCommandS)
-      }
-    }
-  }
+			if expectedCommandS != executedCommandS {
+				linkName := fmt.Sprintf(LinkNameFormat, step.Name, signerKeyID)
+				fmt.Printf("WARNING: Expected command for step '%s' (%s) and command"+
+					" reported by '%s' (%s) differ.\n",
+					step.Name, expectedCommandS, linkName, executedCommandS)
+			}
+		}
+	}
 }
-
 
 /*
 VerifyLinkSignatureThesholds verifies that for each step of the passed layout,
@@ -394,60 +387,59 @@ If for any step of the layout there are not enough links available, the first
 return value is nil and the second return value is the error.
 */
 func VerifyLinkSignatureThesholds(layout Layout,
-    stepsMetadata map[string]map[string]Metablock) (
-    map[string]map[string]Metablock, error) {
-  // This will stores links with valid signature from an authorized functionary
-  // for all steps
-  stepsMetadataVerified := make(map[string]map[string]Metablock)
+	stepsMetadata map[string]map[string]Metablock) (
+	map[string]map[string]Metablock, error) {
+	// This will stores links with valid signature from an authorized functionary
+	// for all steps
+	stepsMetadataVerified := make(map[string]map[string]Metablock)
 
-  // Try to find enough (>= threshold) links each with a valid signature from
-  // distinct authorized functionaries for each step
-  for _, step := range layout.Steps {
-    // This will store links with valid signature from an authorized
-    // functionary for the given step
-    linksPerStepVerified := make(map[string]Metablock)
+	// Try to find enough (>= threshold) links each with a valid signature from
+	// distinct authorized functionaries for each step
+	for _, step := range layout.Steps {
+		// This will store links with valid signature from an authorized
+		// functionary for the given step
+		linksPerStepVerified := make(map[string]Metablock)
 
-    // Check if there are any links at all for the given step
-    linksPerStep, ok := stepsMetadata[step.Name]
-    if !ok || len(linksPerStep) < 1 {
-      continue
-    }
+		// Check if there are any links at all for the given step
+		linksPerStep, ok := stepsMetadata[step.Name]
+		if !ok || len(linksPerStep) < 1 {
+			continue
+		}
 
-    // For each link corresponding to a step, check that the signer key was
-    // authorized, the layout contains a verification key and the signature
-    // verification passes.  Only good links are stored, to verify thresholds
-    // below.
-    for signerKeyID, linkMb := range linksPerStep {
-      for _, authorizedKeyID := range step.PubKeys {
-        if signerKeyID == authorizedKeyID {
-          if verifierKey, ok := layout.Keys[authorizedKeyID]; ok {
-            if err := linkMb.VerifySignature(verifierKey); err == nil {
-              linksPerStepVerified[signerKeyID] = linkMb
-              break
-            }
-          }
-        }
-      }
-    }
-    // Store all good links for a step
-    stepsMetadataVerified[step.Name] = linksPerStepVerified
-  }
+		// For each link corresponding to a step, check that the signer key was
+		// authorized, the layout contains a verification key and the signature
+		// verification passes.  Only good links are stored, to verify thresholds
+		// below.
+		for signerKeyID, linkMb := range linksPerStep {
+			for _, authorizedKeyID := range step.PubKeys {
+				if signerKeyID == authorizedKeyID {
+					if verifierKey, ok := layout.Keys[authorizedKeyID]; ok {
+						if err := linkMb.VerifySignature(verifierKey); err == nil {
+							linksPerStepVerified[signerKeyID] = linkMb
+							break
+						}
+					}
+				}
+			}
+		}
+		// Store all good links for a step
+		stepsMetadataVerified[step.Name] = linksPerStepVerified
+	}
 
-  // Verify threshold for each step
-  for _, step := range layout.Steps {
-    linksPerStepVerified, _ := stepsMetadataVerified[step.Name]
+	// Verify threshold for each step
+	for _, step := range layout.Steps {
+		linksPerStepVerified, _ := stepsMetadataVerified[step.Name]
 
-    if len(linksPerStepVerified) < step.Threshold {
-      linksPerStep, _ := stepsMetadata[step.Name]
-      return nil, fmt.Errorf(`Step '%s' requires '%d' link metadata file(s).
+		if len(linksPerStepVerified) < step.Threshold {
+			linksPerStep, _ := stepsMetadata[step.Name]
+			return nil, fmt.Errorf(`Step '%s' requires '%d' link metadata file(s).
           '%d' out of '%d' available link(s) have a valid signature from an
           authorized signer.`, step.Name,
-          step.Threshold, len(linksPerStepVerified), len(linksPerStep))
-    }
-  }
-  return stepsMetadataVerified, nil
+				step.Threshold, len(linksPerStepVerified), len(linksPerStep))
+		}
+	}
+	return stepsMetadataVerified, nil
 }
-
 
 /*
 LoadLinksForLayout loads for every Step of the passed Layout a Metablock
@@ -474,53 +466,51 @@ ignored. Only a preliminary threshold check is performed, that is, if there
 aren't at least Threshold links for any given step, the first return value
 is nil and the second return value is the error.
 */
-func LoadLinksForLayout(layout Layout, linkDir string)(
-    map[string]map[string]Metablock, error) {
-  stepsMetadata := make(map[string]map[string]Metablock)
+func LoadLinksForLayout(layout Layout, linkDir string) (
+	map[string]map[string]Metablock, error) {
+	stepsMetadata := make(map[string]map[string]Metablock)
 
-  for _, step := range layout.Steps {
-    linksPerStep := make(map[string]Metablock)
+	for _, step := range layout.Steps {
+		linksPerStep := make(map[string]Metablock)
 
-    for _, authorizedKeyId := range step.PubKeys {
-      linkName := fmt.Sprintf(LinkNameFormat, step.Name, authorizedKeyId)
-      linkPath := osPath.Join(linkDir, linkName)
+		for _, authorizedKeyId := range step.PubKeys {
+			linkName := fmt.Sprintf(LinkNameFormat, step.Name, authorizedKeyId)
+			linkPath := osPath.Join(linkDir, linkName)
 
-      var linkMb Metablock
-      if err := linkMb.Load(linkPath); err != nil {
-        continue
-      }
+			var linkMb Metablock
+			if err := linkMb.Load(linkPath); err != nil {
+				continue
+			}
 
-      linksPerStep[authorizedKeyId] = linkMb
-    }
+			linksPerStep[authorizedKeyId] = linkMb
+		}
 
-    if len(linksPerStep) < step.Threshold {
-      return nil, fmt.Errorf(`Step '%s' requires '%d' link metadata file(s),
+		if len(linksPerStep) < step.Threshold {
+			return nil, fmt.Errorf(`Step '%s' requires '%d' link metadata file(s),
           found '%d'.`, step.Name, step.Threshold, len(linksPerStep))
-    }
+		}
 
-    stepsMetadata[step.Name] = linksPerStep
-  }
+		stepsMetadata[step.Name] = linksPerStep
+	}
 
-  return stepsMetadata, nil
+	return stepsMetadata, nil
 }
-
 
 /*
 VerifyLayoutExpiration verifies that the passed Layout has not expired.  It
 returns an error if the (zulu) date in the Expires field is in the past.
 */
 func VerifyLayoutExpiration(layout Layout) error {
-  expires, err := time.Parse(time.RFC3339, layout.Expires)
-  if err != nil {
-    return err
-  }
-  // Uses timezone of expires, i.e. UTC
-  if time.Until(expires) < 0 {
-    return fmt.Errorf("Layout has expired on '%s'.", expires)
-  }
-  return nil
+	expires, err := time.Parse(time.RFC3339, layout.Expires)
+	if err != nil {
+		return err
+	}
+	// Uses timezone of expires, i.e. UTC
+	if time.Until(expires) < 0 {
+		return fmt.Errorf("Layout has expired on '%s'.", expires)
+	}
+	return nil
 }
-
 
 /*
 VerifyLayoutSignatures verifies for each key in the passed key map the
@@ -530,19 +520,18 @@ Metablock's Signature field does not have a signature for one or more of the
 passed keys, or a matching signature is invalid, an error is returned.
 */
 func VerifyLayoutSignatures(layoutMb Metablock,
-    layoutKeys map[string]Key) error {
-  if len(layoutKeys) < 1 {
-    return fmt.Errorf("Layout verification requires at least one key.")
-  }
+	layoutKeys map[string]Key) error {
+	if len(layoutKeys) < 1 {
+		return fmt.Errorf("Layout verification requires at least one key.")
+	}
 
-  for _, key := range layoutKeys {
-    if err := layoutMb.VerifySignature(key); err != nil {
-      return err
-    }
-  }
-  return nil
+	for _, key := range layoutKeys {
+		if err := layoutMb.VerifySignature(key); err != nil {
+			return err
+		}
+	}
+	return nil
 }
-
 
 /*
 InTotoVerify can be used to verify an entire software supply chain according to
@@ -569,77 +558,77 @@ NOTE: Parameter substitution, sublayout (recursive) verification and artifact
 rules of type "create", "modify" and "delete" are currently not supported.
 */
 func InTotoVerify(layoutPath string, layoutKeys map[string]Key,
-    linkDir string) error {
+	linkDir string) error {
 
-  var layoutMb Metablock
+	var layoutMb Metablock
 
-  // Load layout
-  if err := layoutMb.Load(layoutPath); err != nil {
-    return err
-  }
+	// Load layout
+	if err := layoutMb.Load(layoutPath); err != nil {
+		return err
+	}
 
-  // Verify root signatures
-  if err := VerifyLayoutSignatures(layoutMb, layoutKeys); err != nil {
-    return err
-  }
+	// Verify root signatures
+	if err := VerifyLayoutSignatures(layoutMb, layoutKeys); err != nil {
+		return err
+	}
 
-  // Extract the layout from its Metablock container (for further processing)
-  layout := layoutMb.Signed.(Layout)
+	// Extract the layout from its Metablock container (for further processing)
+	layout := layoutMb.Signed.(Layout)
 
-  // Verify layout expiration
-  if err := VerifyLayoutExpiration(layout); err != nil {
-    return err
-  }
+	// Verify layout expiration
+	if err := VerifyLayoutExpiration(layout); err != nil {
+		return err
+	}
 
-  // TODO: Substitute parameters
+	// TODO: Substitute parameters
 
-  // Load links for layout
-  stepsMetadata, err := LoadLinksForLayout(layout, linkDir)
-  if err != nil {
-    return err
-  }
+	// Load links for layout
+	stepsMetadata, err := LoadLinksForLayout(layout, linkDir)
+	if err != nil {
+		return err
+	}
 
-  // Verify link signatures
-  stepsMetadataVerified, err := VerifyLinkSignatureThesholds(layout,
-      stepsMetadata)
-  if err != nil {
-    return err
-  }
+	// Verify link signatures
+	stepsMetadataVerified, err := VerifyLinkSignatureThesholds(layout,
+		stepsMetadata)
+	if err != nil {
+		return err
+	}
 
-  // TODO: Verify sublayouts
+	// TODO: Verify sublayouts
 
-  // Verify command alignment (WARNING only)
-  VerifyStepCommandAlignment(layout, stepsMetadataVerified)
+	// Verify command alignment (WARNING only)
+	VerifyStepCommandAlignment(layout, stepsMetadataVerified)
 
-  // Given that signature thresholds have been checked above and the rest of
-  // the relevant link properties, i.e. materials and products, have to be
-  // exactly equal, we can reduce the map of steps metadata. However, we error
-  // if the relevant properties are not equal among links of a step.
-  stepsMetadataReduced, err := ReduceStepsMetadata(layout,
-      stepsMetadataVerified)
-  if err != nil {
-    return err
-  }
+	// Given that signature thresholds have been checked above and the rest of
+	// the relevant link properties, i.e. materials and products, have to be
+	// exactly equal, we can reduce the map of steps metadata. However, we error
+	// if the relevant properties are not equal among links of a step.
+	stepsMetadataReduced, err := ReduceStepsMetadata(layout,
+		stepsMetadataVerified)
+	if err != nil {
+		return err
+	}
 
-  // Verify artifact rules
-  if err := VerifyArtifacts(layout.StepsAsInterfaceSlice(), stepsMetadataReduced); err != nil {
-    return err
-  }
+	// Verify artifact rules
+	if err := VerifyArtifacts(layout.StepsAsInterfaceSlice(), stepsMetadataReduced); err != nil {
+		return err
+	}
 
-  inspectionMetadata, err := RunInspections(layout)
-  if err != nil {
-    return err
-  }
+	inspectionMetadata, err := RunInspections(layout)
+	if err != nil {
+		return err
+	}
 
-  // Add steps metadata to inspection metadata, because inspection artifact
-  // rules may also refer to artifacts reported by step links
-  for k, v := range stepsMetadataReduced {
-    inspectionMetadata[k] = v
-  }
+	// Add steps metadata to inspection metadata, because inspection artifact
+	// rules may also refer to artifacts reported by step links
+	for k, v := range stepsMetadataReduced {
+		inspectionMetadata[k] = v
+	}
 
-  if err := VerifyArtifacts(layout.InspectAsInterfaceSlice(), inspectionMetadata); err != nil {
-    return err
-  }
+	if err := VerifyArtifacts(layout.InspectAsInterfaceSlice(), inspectionMetadata); err != nil {
+		return err
+	}
 
-  return nil
+	return nil
 }

--- a/in_toto/verifylib_test.go
+++ b/in_toto/verifylib_test.go
@@ -1,12 +1,12 @@
 package in_toto
 
 import (
-  "os"
-  "fmt"
-  "testing"
-  "path/filepath"
-  "io/ioutil"
-  )
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 const testData = "../test/data"
 
@@ -14,65 +14,64 @@ const testData = "../test/data"
 // This can be used for test setup and teardown, e.g. copy test data to a tmp
 // test dir, change to that dir and remove the and contents in the end
 func TestMain(m *testing.M) {
-  testDir, err := ioutil.TempDir("", "in_toto_test_dir")
-  if err != nil {
-    panic("Cannot create temp test dir")
-  }
+	testDir, err := ioutil.TempDir("", "in_toto_test_dir")
+	if err != nil {
+		panic("Cannot create temp test dir")
+	}
 
-  // Copy test files to temp test directory
-  // NOTE: Only works for a flat directory of files
-  testFiles, _ := filepath.Glob(filepath.Join(testData, "*"))
-  for _, inputPath := range testFiles {
-    input, err := ioutil.ReadFile(inputPath)
-    if err != nil {
-      panic(fmt.Sprintf("Cannot copy test files (read error: %s)", err))
-    }
-    outputPath := filepath.Join(testDir, filepath.Base(inputPath))
-    err = ioutil.WriteFile(outputPath, input, 0644)
-    if err != nil {
-      panic(fmt.Sprintf("Cannot copy test files (write error: %s)", err))
-    }
-  }
+	// Copy test files to temp test directory
+	// NOTE: Only works for a flat directory of files
+	testFiles, _ := filepath.Glob(filepath.Join(testData, "*"))
+	for _, inputPath := range testFiles {
+		input, err := ioutil.ReadFile(inputPath)
+		if err != nil {
+			panic(fmt.Sprintf("Cannot copy test files (read error: %s)", err))
+		}
+		outputPath := filepath.Join(testDir, filepath.Base(inputPath))
+		err = ioutil.WriteFile(outputPath, input, 0644)
+		if err != nil {
+			panic(fmt.Sprintf("Cannot copy test files (write error: %s)", err))
+		}
+	}
 
-  cwd, _:= os.Getwd()
-  os.Chdir(testDir)
+	cwd, _ := os.Getwd()
+	os.Chdir(testDir)
 
-  // Always change back to where we were and remove the temp directory
-  defer os.Chdir(cwd)
-  defer os.RemoveAll(testDir)
+	// Always change back to where we were and remove the temp directory
+	defer os.Chdir(cwd)
+	defer os.RemoveAll(testDir)
 
-  // Run tests
-  os.Exit(m.Run())
+	// Run tests
+	os.Exit(m.Run())
 }
 
 func TestInTotoVerifyPass(t *testing.T) {
-  // TODO: The test layout has a hardcoded expiration date. We need to
-  // implement signing and create the date and sign the layout on the fly.
-  layoutPath := "demo.layout.template"
-  pubKeyPath := "alice.pub"
-  linkDir := "."
+	// TODO: The test layout has a hardcoded expiration date. We need to
+	// implement signing and create the date and sign the layout on the fly.
+	layoutPath := "demo.layout.template"
+	pubKeyPath := "alice.pub"
+	linkDir := "."
 
-  var pubKey Key
-  if err := pubKey.LoadPublicKey(pubKeyPath); err != nil {
-    t.Error(err)
-  }
+	var pubKey Key
+	if err := pubKey.LoadPublicKey(pubKeyPath); err != nil {
+		t.Error(err)
+	}
 
-  var layouKeys = map[string]Key{
-    pubKey.KeyId: pubKey,
-  }
+	var layouKeys = map[string]Key{
+		pubKey.KeyId: pubKey,
+	}
 
-  // No error should occur
-  if err := InTotoVerify(layoutPath, layouKeys, linkDir); err != nil {
-    t.Error(err)
-  }
+	// No error should occur
+	if err := InTotoVerify(layoutPath, layouKeys, linkDir); err != nil {
+		t.Error(err)
+	}
 }
 
-
 func TestInTotoVerifyLayoutDoesNotExist(t *testing.T) {
-  err := InTotoVerify("layout/does/not/exist", map[string]Key{},
-      "link/dir/does/not/matter")
-  // Asssert error type to PathError
-  if _, ok := err.(*os.PathError); ok == false {
-    t.Fail()
-  }
+	err := InTotoVerify("layout/does/not/exist", map[string]Key{},
+		"link/dir/does/not/matter")
+	// Asssert error type to PathError
+	if _, ok := err.(*os.PathError); ok == false {
+		t.Fail()
+	}
 }


### PR DESCRIPTION
**Fixes issue #**:
Addresses @agamdua's suggestion in #9 

**Description of pull request**:
Makes all go code of this repo `gofmt` compliant. Changes include:
- indent with tabs instead of spaces
- align assignment parameters and inline comments with spaces

This PR also modifies the CI/CD scripts to check `gofmt`'s output in automated builds and fail if new code does not comply.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


