### PR TITLE
Fix wrong use of multi-line string

### DIFF
--- a/in_toto/model.go
+++ b/in_toto/model.go
@@ -224,8 +224,8 @@ func (mb *Metablock) Load(path string) error {
 		mb.Signed = layout
 
 	} else {
-		return fmt.Errorf(`The '_type' field of the 'signed' part of a metadata
-        file must be one of 'link' or 'layout'`)
+		return fmt.Errorf("The '_type' field of the 'signed' part of a metadata" +
+			" file must be one of 'link' or 'layout'")
 	}
 
 	return nil

--- a/in_toto/verifylib.go
+++ b/in_toto/verifylib.go
@@ -432,10 +432,10 @@ func VerifyLinkSignatureThesholds(layout Layout,
 
 		if len(linksPerStepVerified) < step.Threshold {
 			linksPerStep, _ := stepsMetadata[step.Name]
-			return nil, fmt.Errorf(`Step '%s' requires '%d' link metadata file(s).
-          '%d' out of '%d' available link(s) have a valid signature from an
-          authorized signer.`, step.Name,
-				step.Threshold, len(linksPerStepVerified), len(linksPerStep))
+			return nil, fmt.Errorf("Step '%s' requires '%d' link metadata file(s)."+
+				" '%d' out of '%d' available link(s) have a valid signature from an"+
+				" authorized signer.", step.Name, step.Threshold,
+				len(linksPerStepVerified), len(linksPerStep))
 		}
 	}
 	return stepsMetadataVerified, nil
@@ -486,8 +486,8 @@ func LoadLinksForLayout(layout Layout, linkDir string) (
 		}
 
 		if len(linksPerStep) < step.Threshold {
-			return nil, fmt.Errorf(`Step '%s' requires '%d' link metadata file(s),
-          found '%d'.`, step.Name, step.Threshold, len(linksPerStep))
+			return nil, fmt.Errorf("Step '%s' requires '%d' link metadata file(s),"+
+				" found '%d'.", step.Name, step.Threshold, len(linksPerStep))
 		}
 
 		stepsMetadata[step.Name] = linksPerStep


### PR DESCRIPTION
**Fixes issue #**:
None

**Description of pull request**:
Multi-line strings wrapped in backticks "\`" include given newlines and indentation. To split strings over multiple lines in e.g. function parameters we need to concatenate them.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


