### PR TITLE
Add Set struct and set operations

### DIFF
--- a/in_toto/util.go
+++ b/in_toto/util.go
@@ -1,0 +1,117 @@
+package in_toto
+
+import (
+	"fmt"
+	"path/filepath"
+)
+
+/*
+Set represents a data structure for set operations. See `NewSet` for how to
+create a Set, and available Set receivers for useful set operations.
+
+Under the hood Set aliases map[string]struct{}, where the map keys are the set
+elements and the map values are a memory-efficient way of storing the keys.
+*/
+type Set map[string]struct{}
+
+/*
+NewSet creates a new Set, assigns it the optionally passed variadic string
+elements, and returns it.
+*/
+func NewSet(elems ...string) Set {
+	var s Set
+	s = make(map[string]struct{})
+	for _, elem := range elems {
+		s.Add(elem)
+	}
+	return s
+}
+
+/*
+Has returns True if the passed string is member of the set on which it was
+called and False otherwise.
+*/
+func (s Set) Has(elem string) bool {
+	_, ok := s[elem]
+	return ok
+}
+
+/*
+Add adds the passed string to the set on which it was called, if the string is
+not a member of the set.
+*/
+func (s Set) Add(elem string) {
+	s[elem] = struct{}{}
+}
+
+/*
+Remove removes the passed string from the set on which was is called, if the
+string is a member of the set.
+*/
+func (s Set) Remove(elem string) {
+	delete(s, elem)
+}
+
+/*
+Intersection creates and returns a new Set with the elements of the set on
+which it was called that are also in the passed set.
+*/
+func (s Set) Intersection(s2 Set) Set {
+	res := NewSet()
+	for elem := range s {
+		if s2.Has(elem) == false {
+			continue
+		}
+		res.Add(elem)
+	}
+	return res
+}
+
+/*
+Difference creates and returns a new Set with the elements of the set on
+which it was called that are not in the passed set.
+*/
+func (s Set) Difference(s2 Set) Set {
+	res := NewSet()
+	for elem := range s {
+		if s2.Has(elem) {
+			continue
+		}
+		res.Add(elem)
+	}
+	return res
+}
+
+/*
+Filter creates and returns a new Set with the elements of the set on which it
+was called that match the passed pattern. A matching error is treated like a
+non-match plus a warning is printed.
+*/
+func (s Set) Filter(pattern string) Set {
+	res := NewSet()
+	for elem := range s {
+		matched, err := filepath.Match(pattern, elem)
+		if err != nil {
+			fmt.Printf("WARNING: %s, pattern was '%s'\n", err, pattern)
+			continue
+		}
+		if !matched {
+			continue
+		}
+		res.Add(elem)
+	}
+	return res
+}
+
+/*
+Slice creates and returns an unordered string slice with the elements of the
+set on which it was called.
+*/
+func (s Set) Slice() []string {
+	var res []string
+	res = make([]string, 0, len(s))
+	for elem := range s {
+		res = append(res, elem)
+	}
+	return res
+}

--- a/in_toto/util_test.go
+++ b/in_toto/util_test.go
@@ -1,0 +1,84 @@
+package in_toto
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestSet(t *testing.T) {
+	testSet := NewSet()
+	if testSet.Has("a") {
+		t.Errorf("not added element 'a' in set %s", testSet.Slice())
+	}
+	testSet.Add("a")
+	if !testSet.Has("a") {
+		t.Errorf("added element 'a' not in set %s", testSet.Slice())
+	}
+	testSet.Add("a")
+	setLen := len(testSet)
+	if setLen != 1 {
+		t.Errorf("expected len 1, got %v for set %s", setLen, testSet.Slice())
+	}
+	testSet.Remove("a")
+	if testSet.Has("a") {
+		t.Errorf("removed element 'a' in set %s", testSet.Slice())
+	}
+	// Nothing should happen
+	testSet.Remove("a")
+}
+
+func TestSetIntersection(t *testing.T) {
+	testSet1 := NewSet("a", "b", "c")
+	testSet2 := NewSet("b", "c", "d")
+	expected := NewSet("b", "c")
+	res := testSet1.Intersection(testSet2)
+
+	if !reflect.DeepEqual(res, expected) {
+		t.Errorf("expected %s, got %s", expected.Slice(), res.Slice())
+	}
+}
+
+func TestSetDifference(t *testing.T) {
+	testSet1 := NewSet("a", "b", "c")
+	testSet2 := NewSet("b", "c", "d")
+	expected := NewSet("a")
+	res := testSet1.Difference(testSet2)
+
+	if !reflect.DeepEqual(res, expected) {
+		t.Errorf("expected %s, got %s", expected.Slice(), res.Slice())
+	}
+}
+
+func TestSetSlice(t *testing.T) {
+	testSet := NewSet("a", "b", "c")
+	expected := []string{"a", "b", "c"}
+
+	res := testSet.Slice()
+	sort.Strings(res)
+	if !reflect.DeepEqual(res, expected) {
+		t.Errorf("expected: %s, got: %s", expected, res)
+	}
+}
+
+func TestSetFilter(t *testing.T) {
+	cases := []struct {
+		name           string
+		pattern        string
+		base, expected Set
+	}{
+		{"match foo", "foo", NewSet("foo", "foobar", "bar"), NewSet("foo")},
+		{"match with wildcard", "foo*", NewSet("foo", "foobar", "bar"), NewSet("foo", "foobar")},
+		{"no match", "foo", NewSet("bar"), NewSet()},
+		{"no match (due to invalid pattern)", "[", NewSet("["), NewSet()},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := tc.base.Filter(tc.pattern)
+			if !reflect.DeepEqual(res, tc.expected) {
+				t.Errorf("expected: %s, got: %s", tc.expected.Slice(), res.Slice())
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Fixes issue #**:
pre-requisite for #28.

**Description of pull request**:
Golang does not support a set data structure (due to missing generics). This PR adds a simple set data structure for string elements and receivers for common set operations `has`, `add`, `remove`, `intersection` and `difference`, plus two handy receivers for pattern matching (filter) and casting a set to a string array (slice).

*Teaser*: 
The newly added `Filter` and `Intersection` functions will replace `verifylib`'s `FnFilter` and `Subtract` functions, when working on #28.

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


