### PR TITLE
updating go version to 1.12 in appveyor and travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - "1.11"
+  - "1.12"
 
 before_install:
   - go get github.com/mattn/goveralls

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ clone_folder: c:\gopath\src\github.com\in-toto\in-toto-golang
 environment:
   GOPATH: c:\gopath
 
-stack: go 1.11
+stack: go 1.12
 
 test_script:
   - ps: if (gofmt -l in_toto) { Write-Error "Use gofmt" }


### PR DESCRIPTION
Updates Version of Go to 1.12 for Travis and AppVeyor as per discussion on below PR

https://github.com/in-toto/in-toto-golang/pull/41#issue-270178671
