### PR TITLE
Add test command to Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,6 @@ before_install:
   - go get github.com/mattn/goveralls
 
 script:
+  - go test ./...
   - test -z $(gofmt -l in_toto)
   - $GOPATH/bin/goveralls -service=travis-ci


### PR DESCRIPTION
The current Travis config does not actually test the package.
This fix adds the `go test ./...` command to the Travis configuration.

Signed-off-by: Radu M <root@radu.sh>