### PR TITLE
Fix encode canonical

### DIFF
--- a/in_toto/canonicaljson.go
+++ b/in_toto/canonicaljson.go
@@ -8,7 +8,6 @@ import (
 	"reflect"
 	"regexp"
 	"sort"
-	"strconv"
 )
 
 /*
@@ -50,13 +49,17 @@ func _encodeCanonical(obj interface{}, result *bytes.Buffer) (err error) {
 			result.WriteString("false")
 		}
 
-	// Golang's JSON decoder, which we use before canonicalization, in order to
-	// transform any passed object to a generic JSON object, stores JSON
-	// numbers as float64. Hence, it is safe to expect all numeric values to be
-	// float64.
-	case float64:
-		// The used canonicalization spec only allows non-floating point numbers
-		result.WriteString(strconv.Itoa(int(objAsserted)))
+	// The wrapping `EncodeCanonical` function decodes the passed json data with
+	// `decoder.UseNumber` so that any numeric value is stored as `json.Number`
+	// (instead of the default `float64`). This allows us to assert that it is a
+	// non-floating point number, which are the only numbers allowed by the used
+	// canonicalization specification.
+	case json.Number:
+		if _, err := objAsserted.Int64(); err != nil {
+			panic(fmt.Sprintf("Can't canonicalize floating point number '%s'",
+				objAsserted))
+		}
+		result.WriteString(objAsserted.String())
 
 	case nil:
 		result.WriteString("null")
@@ -123,7 +126,10 @@ func EncodeCanonical(obj interface{}) ([]byte, error) {
 		return nil, err
 	}
 	var jsonMap interface{}
-	if err := json.Unmarshal(data, &jsonMap); err != nil {
+
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	if err := dec.Decode(&jsonMap); err != nil {
 		return nil, err
 	}
 

--- a/in_toto/canonicaljson.go
+++ b/in_toto/canonicaljson.go
@@ -65,7 +65,9 @@ func _encodeCanonical(obj interface{}, result *bytes.Buffer) (err error) {
 	case []interface{}:
 		result.WriteString("[")
 		for i, val := range objAsserted {
-			_encodeCanonical(val, result)
+			if err := _encodeCanonical(val, result); err != nil {
+				return err
+			}
 			if i < (len(objAsserted) - 1) {
 				result.WriteString(",")
 			}
@@ -85,9 +87,13 @@ func _encodeCanonical(obj interface{}, result *bytes.Buffer) (err error) {
 
 		// Canonicalize map
 		for i, key := range mapKeys {
-			_encodeCanonical(key, result)
+			if err := _encodeCanonical(key, result); err != nil {
+				return err
+			}
 			result.WriteString(":")
-			_encodeCanonical(objAsserted[key], result)
+			if err := _encodeCanonical(objAsserted[key], result); err != nil {
+				return err
+			}
 			if i < (len(mapKeys) - 1) {
 				result.WriteString(",")
 			}

--- a/in_toto/canonicaljson.go
+++ b/in_toto/canonicaljson.go
@@ -90,9 +90,11 @@ func _encodeCanonical(obj interface{}, result *bytes.Buffer) (err error) {
 
 		// Canonicalize map
 		for i, key := range mapKeys {
-			if err := _encodeCanonical(key, result); err != nil {
-				return err
-			}
+			// Note: `key` must be a `string` (see `case map[string]interface{}`) and
+			// canonicalization of strings cannot err out (see `case string`), thus
+			// no error handling is needed here.
+			_encodeCanonical(key, result)
+
 			result.WriteString(":")
 			if err := _encodeCanonical(objAsserted[key], result); err != nil {
 				return err

--- a/in_toto/canonicaljson_test.go
+++ b/in_toto/canonicaljson_test.go
@@ -23,14 +23,15 @@ func TestEncodeCanonical(t *testing.T) {
 			"true":   true,
 			"false":  false,
 			"nil":    nil,
-			"float":  3.14159265359,
+			"int":    3,
+			"int2":   float64(42),
 			"string": `\"`,
 		},
 	}
 	expectedResult := []string{
 		`{"keyid":"","keyid_hash_algorithms":null,"keytype":"","keyval":{"private":"","public":""},"scheme":""}`,
 		`{"keyid":"id","keyid_hash_algorithms":["hash"],"keytype":"type","keyval":{"private":"priv","public":"pub"},"scheme":"scheme"}`,
-		`{"false":false,"float":3,"nil":null,"string":"\\\"","true":true}`,
+		`{"false":false,"int":3,"int2":42,"nil":null,"string":"\\\"","true":true}`,
 		"",
 	}
 	for i := 0; i < len(objects); i++ {
@@ -41,13 +42,24 @@ func TestEncodeCanonical(t *testing.T) {
 				result, err, expectedResult[i])
 		}
 	}
+}
 
-	// Cannot canonicalize function
-	result, err := EncodeCanonical(TestEncodeCanonical)
-	expectedError := "json: unsupported type"
-	if err == nil || !strings.Contains(err.Error(), expectedError) {
-		t.Errorf("EncodeCanonical returned (%s, %s), expected '%s' error",
-			result, err, expectedError)
+func TestEncodeCanonicalErr(t *testing.T) {
+	objects := []interface{}{
+		map[string]interface{}{"float": 3.14159265359},
+		TestEncodeCanonical,
+	}
+	errPart := []string{
+		"Can't canonicalize floating point number",
+		"unsupported type: func(",
+	}
+
+	for i := 0; i < len(objects); i++ {
+		result, err := EncodeCanonical(objects[i])
+		if err == nil || !strings.Contains(err.Error(), errPart[i]) {
+			t.Errorf("EncodeCanonical returned (%s, %s), expected '%s' error",
+				result, err, errPart[i])
+		}
 	}
 }
 

--- a/in_toto/canonicaljson_test.go
+++ b/in_toto/canonicaljson_test.go
@@ -64,11 +64,19 @@ func TestEncodeCanonicalErr(t *testing.T) {
 }
 
 func Test_encodeCanonical(t *testing.T) {
-	var result bytes.Buffer
-	err := _encodeCanonical(Test_encodeCanonical, &result)
 	expectedError := "Can't canonicalize"
-	if err == nil || !strings.Contains(err.Error(), expectedError) {
-		t.Errorf("EncodeCanonical returned '%s', expected '%s' error",
-			err, expectedError)
+
+	objects := []interface{}{
+		Test_encodeCanonical,
+		[]interface{}{Test_encodeCanonical},
+	}
+
+	for i := 0; i < len(objects); i++ {
+		var result bytes.Buffer
+		err := _encodeCanonical(objects[i], &result)
+		if err == nil || !strings.Contains(err.Error(), expectedError) {
+			t.Errorf("EncodeCanonical returned '%s', expected '%s' error",
+				err, expectedError)
+		}
 	}
 }


### PR DESCRIPTION
**Fixes issue #**:
#49 

**Description of pull request**:
Prior to this change any numeric values were converted to integers during canonicalization. This does not conform with the OLPC canonical JSON specification, which disallows floating point numbers.

This PR changes `EncodeCanonical` to decode any numeric values as `json.Number` (instead of the default `float64`), and `_encodeCanonical` to fail if any `json.Number` is not a whole number.

Note that the json decoder in `Metablock.load` in `models` is not changed, and will decode any numeric values from a loaded json file as `float64`. However, these numbers may still be successfully encoded with `EncodeCanonical` as long as they hold whole numbers (see [tests](https://github.com/lukpueh/in-toto-golang/blob/814100d385dabf507399ff183eba16e3071db142/in_toto/canonicaljson_test.go#L27)).

This PR also fixes an error handling bug in `_encodeCanonical`.


**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


