### PR TITLE
use tabs for code indentation in multi-line comments

### DIFF
--- a/in_toto/keylib.go
+++ b/in_toto/keylib.go
@@ -158,16 +158,17 @@ func VerifySignature(key Key, sig Signature, data []byte) error {
 /*
 ParseEd25519FromPrivateJSON parses an ed25519 private key from the json string.
 These ed25519 keys have the format as generated using in-toto-keygen:
-{
-  "keytype: "ed25519",
-  "scheme": "ed25519",
-  "keyid": ...
-  "keyid_hash_algorithms": [...]
-  "keyval": {
-    "public": "..." # 32 bytes
-    "private": "..." # 32 bytes
-  }
-}
+
+	{
+		"keytype: "ed25519",
+		"scheme": "ed25519",
+		"keyid": ...
+		"keyid_hash_algorithms": [...]
+		"keyval": {
+			"public": "..." # 32 bytes
+			"private": "..." # 32 bytes
+		}
+	}
 */
 func ParseEd25519FromPrivateJSON(JSONString string) (Key, error) {
 

--- a/in_toto/model.go
+++ b/in_toto/model.go
@@ -181,12 +181,14 @@ LinkNameFormat represents a format string used to create the filename for a
 signed Link (wrapped in a Metablock). It consists of the name of the link and
 the first 8 characters of the signing key id.  LinkNameFormatShort is for links
 that are not signed, e.g.:
-  fmt.Sprintf(LinkNameFormat, "package",
-      "2f89b9272acfc8f4a0a0f094d789fdb0ba798b0fe41f2f5f417c12f0085ff498")
-  // returns "package.2f89b9272.link"
 
-  fmt.Sprintf(LinkNameFormatShort, "unsigned")
-  // returns "unsigned.link"
+	fmt.Sprintf(LinkNameFormat, "package",
+	"2f89b9272acfc8f4a0a0f094d789fdb0ba798b0fe41f2f5f417c12f0085ff498")
+	// returns "package.2f89b9272.link"
+
+	fmt.Sprintf(LinkNameFormatShort, "unsigned")
+	// returns "unsigned.link"
+
 */
 const LinkNameFormat = "%s.%.8s.link"
 const LinkNameFormatShort = "%s.link"

--- a/in_toto/rulelib.go
+++ b/in_toto/rulelib.go
@@ -20,24 +20,26 @@ var errorMsg string = "Wrong rule format, available formats are:\n" +
 UnpackRule parses the passed rule and extracts and returns the information
 required for rule processing.  It can be used to verify if a rule has a valid
 format.  Available rule formats are:
-  MATCH <pattern> [IN <source-path-prefix>] WITH (MATERIALS|PRODUCTS)
-      [IN <destination-path-prefix>] FROM <step>,
-  CREATE <pattern>,
-  DELETE <pattern>,
-  MODIFY <pattern>,
-  ALLOW <pattern>,
-  DISALLOW <pattern>
+
+	MATCH <pattern> [IN <source-path-prefix>] WITH (MATERIALS|PRODUCTS)
+		[IN <destination-path-prefix>] FROM <step>,
+	CREATE <pattern>,
+	DELETE <pattern>,
+	MODIFY <pattern>,
+	ALLOW <pattern>,
+	DISALLOW <pattern>
 
 Rule tokens are normalized to lower case before returning.  The returned map
 has the following format:
-  {
-    "type": "match" | "create" | "delete" |"modify" | "allow" | "disallow"
-    "pattern": "<file name pattern>",
-    "srcPrefix": "<path or empty string>", // MATCH rule only
-    "dstPrefix": "<path or empty string>", // MATCH rule only
-    "dstType": "materials" | "products">, // MATCH rule only
-    "dstName": "<step name>", // Match rule only
-  }
+
+	{
+		"type": "match" | "create" | "delete" |"modify" | "allow" | "disallow"
+		"pattern": "<file name pattern>",
+		"srcPrefix": "<path or empty string>", // MATCH rule only
+		"dstPrefix": "<path or empty string>", // MATCH rule only
+		"dstType": "materials" | "products">, // MATCH rule only
+		"dstName": "<step name>", // Match rule only
+	}
 
 If the rule does not match any of the available formats the first return value
 is nil and the second return value is the error.
@@ -81,7 +83,6 @@ func UnpackRule(rule []string) (map[string]string, error) {
 			dstType = ruleLower[5]
 			dstPrefix = rule[7]
 			dstName = rule[9]
-
 			// MATCH <pattern> IN <source-path-prefix> WITH (MATERIALS|PRODUCTS) \
 			// FROM <step>
 		} else if ruleLen == 8 && ruleLower[2] == "in" &&

--- a/in_toto/runlib.go
+++ b/in_toto/runlib.go
@@ -11,11 +11,13 @@ import (
 /*
 RecordArtifact reads and hashes the contents of the file at the passed path
 using sha256 and returns a map in the following format:
-  {
-    "<path>": {
-      "sha256": <hex representation of hash>
-    }
-  }
+
+	{
+		"<path>": {
+			"sha256": <hex representation of hash>
+		}
+	}
+
 If reading the file fails, the first return value is nil and the second return
 value is the error.
 */
@@ -50,15 +52,17 @@ func RecordArtifact(path string) (map[string]interface{}, error) {
 RecordArtifacts walks through the passed slice of paths, traversing
 subdirectories, and calls RecordArtifact for each file.  It returns a map in
 the following format:
-  {
-    "<path>": {
-      "sha256": <hex representation of hash>
-    },
-    "<path>": {
-      "sha256": <hex representation of hash>
-    },
-    ...
-  }
+
+	{
+		"<path>": {
+			"sha256": <hex representation of hash>
+		},
+		"<path>": {
+		"sha256": <hex representation of hash>
+		},
+		...
+	}
+
 If recording an artifact fails the first return value is nil and the second
 return value is the error.
 */
@@ -124,11 +128,13 @@ func WaitErrToExitCode(err error) int {
 RunCommand executes the passed command in a subprocess.  The first element of
 cmdArgs is used as executable and the rest as command arguments.  It captures
 and returns stdout, stderr and exit code.  The format of the returned map is:
-  {
-    "return-value": <exit code>,
-    "stdout": "<standard output>",
-    "stderr": "<standard error>"
-  }
+
+	{
+		"return-value": <exit code>,
+		"stdout": "<standard output>",
+		"stderr": "<standard error>"
+	}
+
 If the command cannot be executed or no pipes for stdout or stderr can be
 created the first return value is nil and the second return value is the error.
 NOTE: Since stdout and stderr are captured, they cannot be seen during the

--- a/in_toto/verifylib.go
+++ b/in_toto/verifylib.go
@@ -22,11 +22,13 @@ all files found in the current working directory as materials (before command
 execution) and products (after command execution).  A map with inspection names
 as keys and Metablocks containing the generated link metadata as values is
 returned.  The format is:
-  {
-    <inspection name> : Metablock,
-    <inspection name> : Metablock,
-    ...
-  }
+
+	{
+		<inspection name> : Metablock,
+		<inspection name> : Metablock,
+		...
+	}
+
 If executing the inspection command fails, or if the executed command has a
 non-zero exit code, the first return value is an empty Metablock map and the
 second return value is the error.
@@ -310,11 +312,13 @@ and Products are equal across links for a given step.  This function may be
 used at a time during the overall verification, where link threshold's have
 been verified and subsequent verification only needs one exemplary link per
 step.  The function returns a map with one Metablock (link) per step:
-  {
-    <step name> : Metablock,
-    <step name> : Metablock,
-    ...
-  }
+
+	{
+		<step name> : Metablock,
+		<step name> : Metablock,
+		...
+	}
+
 If links corresponding to the same step report different Materials or different
 Products, the first return value is an empty Metablock map and the second
 return value is the error.
@@ -405,19 +409,21 @@ VerifyLinkSignatureThesholds verifies that for each step of the passed layout,
 there are at least Threshold links, validly signed by different authorized
 functionaries.  The returned map of link metadata per steps contains only
 links with valid signatures from distinct functionaries and has the format:
-  {
-    <step name> : {
-      <key id>: Metablock,
-      <key id>: Metablock,
-      ...
-    },
-    <step name> : {
-      <key id>: Metablock,
-      <key id>: Metablock,
-      ...
-    }
-    ...
-  }
+
+	{
+		<step name> : {
+		<key id>: Metablock,
+		<key id>: Metablock,
+		...
+		},
+		<step name> : {
+		<key id>: Metablock,
+		<key id>: Metablock,
+		...
+		}
+		...
+	}
+
 If for any step of the layout there are not enough links available, the first
 return value is an empty map of Metablock maps and the second return value is
 the error.
@@ -484,19 +490,21 @@ the links may be passed using linkDir.  Link file names are constructed,
 using LinkNameFormat together with the corresponding step name and authorized
 functionary key ids.  A map of link metadata is returned and has the following
 format:
-  {
-    <step name> : {
-      <key id>: Metablock,
-      <key id>: Metablock,
-      ...
-    },
-    <step name> : {
-      <key id>: Metablock,
-      <key id>: Metablock,
-      ...
-    }
-    ...
-  }
+
+	{
+		<step name> : {
+			<key id>: Metablock,
+			<key id>: Metablock,
+			...
+		},
+		<step name> : {
+		<key id>: Metablock,
+		<key id>: Metablock,
+		...
+		}
+		...
+	}
+
 If a link cannot be loaded at a constructed link name or is invalid, it is
 ignored. Only a preliminary threshold check is performed, that is, if there
 aren't at least Threshold links for any given step, the first return value


### PR DESCRIPTION
**Fixes issue #**:

https://github.com/in-toto/in-toto-golang/issues/18

**Description of pull request**:

As mentioned in https://github.com/in-toto/in-toto-golang/issues/18 we have used spaces instead of tabs for code indentation in multi-line comments.
With this commit we are going to use tabs instead of spaces.
This fixes bad formatting in our go documentation.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature
- [x] Docs have been reformatted


