### PR TITLE
shibumi/exclude pattern fix 41

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/in-toto/in-toto-golang
 
 go 1.14
 
-require golang.org/x/crypto v0.0.0-20191029031824-8986dd9e96cf
+require (
+	github.com/shibumi/go-pathspec v1.1.0
+	golang.org/x/crypto v0.0.0-20191029031824-8986dd9e96cf
+)

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
-module github.com/in-toto/in-toto-golang
+module github.com/shibumi/in-toto-golang
 
-go 1.14
+go 1.15
 
 require (
-	github.com/shibumi/go-pathspec v1.1.0
-	golang.org/x/crypto v0.0.0-20191029031824-8986dd9e96cf
+	github.com/shibumi/go-pathspec v1.2.0
+	golang.org/x/crypto v0.0.0-20201112155050-0c6587e931a9
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/shibumi/go-pathspec v1.1.0 h1:a2RXm1j8o8O0QQcfd0e9bFLvM9CiY8bi9qF/l9fJkW8=
+github.com/shibumi/go-pathspec v1.1.0/go.mod h1:bDxCftD0fST3qXIlHoQ/fChsU4mWMVklXp1yPErQaaY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191029031824-8986dd9e96cf h1:fnPsqIDRbCSgumaMCRpoIoF2s4qxv0xSSS0BVZUE/ss=
 golang.org/x/crypto v0.0.0-20191029031824-8986dd9e96cf/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
-github.com/shibumi/go-pathspec v1.1.0 h1:a2RXm1j8o8O0QQcfd0e9bFLvM9CiY8bi9qF/l9fJkW8=
-github.com/shibumi/go-pathspec v1.1.0/go.mod h1:bDxCftD0fST3qXIlHoQ/fChsU4mWMVklXp1yPErQaaY=
+github.com/shibumi/go-pathspec v1.2.0 h1:KVKEDHYk7bQolRMs7nfzjT3SBOCgcXFJzccnj9bsGbA=
+github.com/shibumi/go-pathspec v1.2.0/go.mod h1:bDxCftD0fST3qXIlHoQ/fChsU4mWMVklXp1yPErQaaY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
-golang.org/x/crypto v0.0.0-20191029031824-8986dd9e96cf h1:fnPsqIDRbCSgumaMCRpoIoF2s4qxv0xSSS0BVZUE/ss=
-golang.org/x/crypto v0.0.0-20191029031824-8986dd9e96cf/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20201112155050-0c6587e931a9 h1:umElSU9WZirRdgu2yFHY0ayQkEnKiOC1TtM3fWXFnoU=
+golang.org/x/crypto v0.0.0-20201112155050-0c6587e931a9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/in_toto/runlib_test.go
+++ b/in_toto/runlib_test.go
@@ -48,7 +48,7 @@ func TestSymlinkToFile(t *testing.T) {
 			"sha256": "52947cb78b91ad01fe81cd6aef42d1f6817e92b9e6936c1e5aabb7c98514f355",
 		},
 	}
-	result, err := RecordArtifacts([]string{"foo.tar.gz.sym"}, []string{"sha256"})
+	result, err := RecordArtifacts([]string{"foo.tar.gz.sym"}, []string{"sha256"}, nil)
 	if !reflect.DeepEqual(result, expected) {
 		t.Errorf("RecordArtifacts returned '(%s, %s)', expected '(%s, nil)'",
 			result, err, expected)
@@ -87,7 +87,7 @@ func TestIndirectSymlinkCycles(t *testing.T) {
 	}
 
 	// provoke "symlink cycle detected" error
-	_, err = RecordArtifacts([]string{"symTestA/linkToB.sym", "symTestB/linkToA.sym", "foo.tar.gz"}, []string{"sha256"})
+	_, err = RecordArtifacts([]string{"symTestA/linkToB.sym", "symTestB/linkToA.sym", "foo.tar.gz"}, []string{"sha256"}, nil)
 	if !errors.Is(err, ErrSymCycle) {
 		t.Errorf("We expected: %s, we got: %s", ErrSymCycle, err)
 	}
@@ -130,7 +130,7 @@ func TestSymlinkToFolder(t *testing.T) {
 		t.Errorf("Could not write symTmpfile: %s", err)
 	}
 
-	result, err := RecordArtifacts([]string{"symTmpfile.sym"}, []string{"sha256"})
+	result, err := RecordArtifacts([]string{"symTmpfile.sym"}, []string{"sha256"}, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -182,7 +182,7 @@ func TestSymlinkCycle(t *testing.T) {
 	}
 
 	// provoke "symlink cycle detected" error
-	_, err = RecordArtifacts([]string{"symlinkCycle/symCycle.sym", "foo.tar.gz"}, []string{"sha256"})
+	_, err = RecordArtifacts([]string{"symlinkCycle/symCycle.sym", "foo.tar.gz"}, []string{"sha256"}, nil)
 	if !errors.Is(err, ErrSymCycle) {
 		t.Errorf("We expected: %s, we got: %s", ErrSymCycle, err)
 	}
@@ -205,7 +205,7 @@ func TestRecordArtifacts(t *testing.T) {
 		t.Errorf("Could not write tmpfile: %s", err)
 	}
 	result, err := RecordArtifacts([]string{"foo.tar.gz",
-		"demo.layout.template", "tmpdir/tmpfile"}, []string{"sha256"})
+		"demo.layout.template", "tmpdir/tmpfile"}, []string{"sha256"}, nil)
 	expected := map[string]interface{}{
 		"foo.tar.gz": map[string]interface{}{
 			"sha256": "52947cb78b91ad01fe81cd6aef42d1f6817e92b9e6936c1e5aabb7c98514f355",
@@ -226,7 +226,7 @@ func TestRecordArtifacts(t *testing.T) {
 	}
 
 	// Test error by recording nonexistent artifact
-	result, err = RecordArtifacts([]string{"file-does-not-exist"}, []string{"sha256"})
+	result, err = RecordArtifacts([]string{"file-does-not-exist"}, []string{"sha256"}, nil)
 	if !os.IsNotExist(err) {
 		t.Errorf("RecordArtifacts returned '(%s, %s)', expected '(nil, %s)'",
 			result, err, os.ErrNotExist)
@@ -332,7 +332,7 @@ func TestInTotoRun(t *testing.T) {
 	}
 
 	for _, table := range tablesCorrect {
-		result, err := InTotoRun(linkName, table.materialPaths, table.productPaths, table.cmdArgs, table.key, table.hashAlgorithms)
+		result, err := InTotoRun(linkName, table.materialPaths, table.productPaths, table.cmdArgs, table.key, table.hashAlgorithms, nil)
 		if !reflect.DeepEqual(result, table.result) {
 			t.Errorf("InTotoRun returned '(%s, %s)', expected '(%s, nil)'", result, err, table.result)
 		} else {
@@ -376,7 +376,7 @@ func TestInTotoRun(t *testing.T) {
 	}
 
 	for _, table := range tablesInvalid {
-		result, err := InTotoRun(linkName, table.materialPaths, table.productPaths, table.cmdArgs, table.key, table.hashAlgorithms)
+		result, err := InTotoRun(linkName, table.materialPaths, table.productPaths, table.cmdArgs, table.key, table.hashAlgorithms, nil)
 		if err == nil {
 			t.Errorf("InTotoRun returned '(%s, %s)', expected error",
 				result, err)

--- a/in_toto/verifylib.go
+++ b/in_toto/verifylib.go
@@ -39,7 +39,7 @@ func RunInspections(layout Layout) (map[string]Metablock, error) {
 	for _, inspection := range layout.Inspect {
 
 		linkMb, err := InTotoRun(inspection.Name, []string{"."}, []string{"."},
-			inspection.Run, Key{}, []string{"sha256"})
+			inspection.Run, Key{}, []string{"sha256"}, nil)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Note: This PR is based on PR #41, I couldn't work on the branch directly, because I am not a project maintainer, so I checkout out PR #41 and opened a new PR instead. With this approach we can still list @ayush159 as author for the code he wrote.

**EDIT: I rewrote everything from scratch**

I am right now working on:

* adding documentation (The Apply... func is missing documentation. The func is being exported, so we should definitely add some docs for it)
* Removing unnecessary things or improving error messages. For example: 

https://github.com/in-toto/in-toto-golang/pull/41/files#diff-73e399e3c84826b077d43cc4cbc98e7eR103


Original PR description is below:

**Fixes issue #33**:

**Description of pull request:**
Used go-git to implement gitignore style pattern parsing. Changed the signature of RecordArtifacts function in runlib.go . Added exclude pattern in method signature. If exclude patterns not available, pass nil.

Please verify and check that the pull request fulfills the following
requirements:

- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature