### PR TITLE
implement symlink functionality with filepath.EvalSymlinks()

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/in-toto/in-toto-golang
 
 go 1.13
 
-require golang.org/x/crypto v0.0.0-20191029031824-8986dd9e96cf
+require (
+	golang.org/x/crypto v0.0.0-20191029031824-8986dd9e96cf
+	golang.org/x/tools v0.0.0-20200604183345-4d5ea46c79fe // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,5 @@
 module github.com/in-toto/in-toto-golang
 
-go 1.13
+go 1.14
 
-require (
-	golang.org/x/crypto v0.0.0-20191029031824-8986dd9e96cf
-	golang.org/x/tools v0.0.0-20200604183345-4d5ea46c79fe // indirect
-)
+require golang.org/x/crypto v0.0.0-20191029031824-8986dd9e96cf

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,7 @@
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20191029031824-8986dd9e96cf h1:fnPsqIDRbCSgumaMCRpoIoF2s4qxv0xSSS0BVZUE/ss=
+golang.org/x/crypto v0.0.0-20191029031824-8986dd9e96cf/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/in_toto/runlib.go
+++ b/in_toto/runlib.go
@@ -10,6 +10,11 @@ import (
 )
 
 /*
+ErrSymCycle signals a detected symlink cycle in our RecordArtifacts() function.
+*/
+var ErrSymCycle = errors.New("symlink cycle detected")
+
+/*
 RecordArtifact reads and hashes the contents of the file at the passed path
 using sha256 and returns a map in the following format:
 
@@ -22,7 +27,6 @@ using sha256 and returns a map in the following format:
 If reading the file fails, the first return value is nil and the second return
 value is the error.
 */
-
 func RecordArtifact(path string) (map[string]interface{}, error) {
 
 	hashObjectMap := createMap()
@@ -48,11 +52,6 @@ func RecordArtifact(path string) (map[string]interface{}, error) {
 	// Return it in a format that is conformant with link metadata artifacts
 	return hashedContentsMap, nil
 }
-
-/*
-ErrSymCycle signals a detected symlink cycle in our RecordArtifacts() function.
-*/
-var ErrSymCycle error = errors.New("symlink cycle detected")
 
 /*
 RecordArtifacts walks through the passed slice of paths, traversing

--- a/in_toto/runlib.go
+++ b/in_toto/runlib.go
@@ -76,14 +76,9 @@ If recording an artifact fails the first return value is nil and the second
 return value is the error.
 */
 func RecordArtifacts(paths []string) (evalArtifacts map[string]interface{}, err error) {
-	// check if visitedSymlinks has been initialized
-	// if not: generate a new set
-	if visitedSymlinks == nil {
-		visitedSymlinks = NewSet()
-	}
+	// Make sure to initialize a fresh hashset for every RecordArtifacts call
+	visitedSymlinks = NewSet()
 	evalArtifacts, err = recordArtifacts(paths)
-	// tear down visitedSymlinks
-	visitedSymlinks = nil
 	// pass result and error through
 	return evalArtifacts, err
 }

--- a/in_toto/runlib.go
+++ b/in_toto/runlib.go
@@ -50,9 +50,9 @@ func RecordArtifact(path string) (map[string]interface{}, error) {
 }
 
 /*
-SymCycleErr signals a detected symlink cycle in our RecordArtifacts() function.
+ErrSymCycle signals a detected symlink cycle in our RecordArtifacts() function.
 */
-var SymCycleErr error = errors.New("symlink cycle detected")
+var ErrSymCycle error = errors.New("symlink cycle detected")
 
 /*
 RecordArtifacts walks through the passed slice of paths, traversing
@@ -74,7 +74,7 @@ return value is the error.
 */
 func RecordArtifacts(paths []string, depth uint) (map[string]interface{}, error) {
 	if depth > 10 {
-		return nil, SymCycleErr
+		return nil, ErrSymCycle
 	}
 	artifacts := make(map[string]interface{})
 	// NOTE: Walk cannot follow symlinks

--- a/in_toto/runlib.go
+++ b/in_toto/runlib.go
@@ -97,8 +97,8 @@ func RecordArtifacts(paths []string) (map[string]interface{}, error) {
 				// chain via filepath.EvalSymlinks. We use EvalSymlinks here,
 				// because with os.Readlink() we would just read the next
 				// element in a possible symlink chain. This would mean more
-				// iterations. infoMode()&os.ModeSymlink uses the file file
-				// type bitmap to check for a symlink.
+				// iterations. infoMode()&os.ModeSymlink uses the file
+				// type bitmask to check for a symlink.
 				if info.Mode()&os.ModeSymlink == os.ModeSymlink {
 					// return with error if we detect a symlink cycle
 					if _, ok := visitedSymlinks[path]; ok {

--- a/in_toto/runlib_test.go
+++ b/in_toto/runlib_test.go
@@ -105,7 +105,65 @@ func TestSymlinkToFolder(t *testing.T) {
 	if err := os.Remove("symTest/"); err != nil {
 		t.Errorf("Could not remove path symTest: %s", err)
 	}
+}
 
+// This test provokes a symlink cycle
+func TestSymlinkCycle(t *testing.T) {
+	if err := os.Mkdir("symlinkCycle/", 0700); err != nil {
+		t.Errorf("Could not create tmpdir: %s", err)
+	}
+
+	// we need to get the current working directory here, otherwise
+	// os.Symlink() will create a wrong symlink
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Error(err)
+	}
+	// create a cycle ./symlinkCycle/symCycle.sym -> ./symlinkCycle/
+	if err := os.Symlink(dir+"/symlinkCycle", "symlinkCycle/symCycle.sym"); err != nil {
+		t.Errorf("Could not create a symlink: %s", err)
+	}
+
+	p1 := filepath.FromSlash("symlinkCycle/symCycleTestFile.txt")
+	p2 := filepath.FromSlash("symlinkCycle/symCycle.sym")
+
+	if err := ioutil.WriteFile(p1, []byte("abc"), 0400); err != nil {
+		t.Errorf("Could not write symCycleTestFile.txt: %s", err)
+	}
+
+	result, err := RecordArtifacts([]string{"symlinkCycle/symCycleTestFile.txt", "symlinkCycle/symCycle.sym", "foo.tar.gz"})
+	if err != nil {
+		t.Error(err)
+	}
+
+	expected := map[string]interface{}{
+		"foo.tar.gz": map[string]interface{}{
+			"sha256": "52947cb78b91ad01fe81cd6aef42d1f6817e92b9e6936c1e5aabb7c98514f355",
+		},
+		p1: map[string]interface{}{
+			"sha256": "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+		},
+		p2: map[string]interface{}{
+			"sha256": "...",
+		},
+	}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("RecordArtifacts returned '(%s, %s)', expected '(%s, nil)'",
+			result, err, expected)
+	}
+
+	// make sure to clean up everything
+	if err := os.Remove("symlinkCycle/symCycleTestFile.txt"); err != nil {
+		t.Errorf("Could not remove path symlinkCycle/symCycleTestFile.txt: %s", err)
+	}
+
+	if err := os.Remove("symlinkCycle/symCycle.sym"); err != nil {
+		t.Errorf("Could not remove path symlinkCycle/symCycle.sym: %s", err)
+	}
+
+	if err := os.Remove("symlinkCycle"); err != nil {
+		t.Errorf("Could not remove path symlinkCycle: %s", err)
+	}
 }
 
 func TestRecordArtifacts(t *testing.T) {

--- a/in_toto/runlib_test.go
+++ b/in_toto/runlib_test.go
@@ -126,8 +126,8 @@ func TestSymlinkCycle(t *testing.T) {
 
 	// provoke "symlink cycle detected" error
 	_, err = RecordArtifacts([]string{"symlinkCycle/symCycle.sym", "foo.tar.gz"}, 0)
-	if !errors.Is(err, SymCycleErr) {
-		t.Errorf("We expected: %s, we got: %s", SymCycleErr, err)
+	if !errors.Is(err, ErrSymCycle) {
+		t.Errorf("We expected: %s, we got: %s", ErrSymCycle, err)
 	}
 
 	if err := os.Remove("symlinkCycle/symCycle.sym"); err != nil {

--- a/in_toto/runlib_test.go
+++ b/in_toto/runlib_test.go
@@ -27,6 +27,81 @@ func TestRecordArtifact(t *testing.T) {
 	}
 }
 
+// TestSymlinkToFile checks if we can follow symlinks to a file
+// Note: Symlink files are invisible for InToto right now.
+// Therefore if we have a symlink like: foo.tar.gz.sym -> foo.tar.gz
+// We will only calculate the hash for for.tar.gz
+// The symlink will not be added to the list right now, nor will we calculate a checksum for it.
+func TestSymlinkToFile(t *testing.T) {
+	if err := os.Symlink("foo.tar.gz", "foo.tar.gz.sym"); err != nil {
+		t.Errorf("Could not create a symlink: %s", err)
+	}
+
+	expected := map[string]interface{}{
+		"foo.tar.gz": map[string]interface{}{
+			"sha256": "52947cb78b91ad01fe81cd6aef42d1f6817e92b9e6936c1e5aabb7c98514f355",
+		},
+	}
+	result, err := RecordArtifacts([]string{"foo.tar.gz.sym"})
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("RecordArtifacts returned '(%s, %s)', expected '(%s, nil)'",
+			result, err, expected)
+	}
+
+	if err := os.Remove("foo.tar.gz.sym"); err != nil {
+		t.Errorf("Could not remove foo.tar.gz.sym: %s", err)
+	}
+}
+
+// TestSymlinkToFolder checks if we are successfully following symlinks to folders
+func TestSymlinkToFolder(t *testing.T) {
+	if err := os.MkdirAll("symTest/symTest2", 0700); err != nil {
+		t.Errorf("Could not create tmpdir: %s", err)
+	}
+
+	if err := os.Symlink("symTest/symTest2", "symTmpfile.sym"); err != nil {
+		t.Errorf("Could not create a symlink: %s", err)
+	}
+
+	if err := ioutil.WriteFile("symTest/symTest2/symTmpfile", []byte("abc"), 0400); err != nil {
+		t.Errorf("Could not write symTmpfile: %s", err)
+	}
+
+	result, err := RecordArtifacts([]string{"symTmpfile.sym"})
+	if err != nil {
+		t.Error(err)
+	}
+
+	expected := map[string]interface{}{
+		"symTest/symTest2/symTmpfile": map[string]interface{}{
+			"sha256": "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+		},
+	}
+
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("RecordArtifacts returned '(%s, %s)', expected '(%s, nil)'",
+			result, err, expected)
+	}
+
+	// make sure to clean up everything
+	if err := os.Remove("symTest/symTest2/symTmpfile"); err != nil {
+		t.Errorf("Could not remove path symTest/symTest2/symTmpfile: %s", err)
+	}
+
+	if err := os.Remove("symTmpfile.sym"); err != nil {
+		t.Errorf("Could not remove path symTest/symTest2/symTmpfile.sym: %s", err)
+	}
+
+	if err := os.Remove("symTest/symTest2"); err != nil {
+		t.Errorf("Could not remove path symTest/symTest2: %s", err)
+	}
+
+	if err := os.Remove("symTest/"); err != nil {
+		t.Errorf("Could not remove path symTest: %s", err)
+	}
+
+}
+
 func TestRecordArtifacts(t *testing.T) {
 	// Test successfully record multiple artifacts including temporary subdir
 	if err := os.Mkdir("tmpdir", 0700); err != nil {

--- a/in_toto/runlib_test.go
+++ b/in_toto/runlib_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 )
@@ -63,7 +64,12 @@ func TestSymlinkToFolder(t *testing.T) {
 		t.Errorf("Could not create a symlink: %s", err)
 	}
 
-	if err := ioutil.WriteFile("symTest/symTest2/symTmpfile", []byte("abc"), 0400); err != nil {
+	// create a filepath from slash, because otherwise
+	// our tests are going to fail, because the path matching will
+	// not work correctly on Windows
+	p := filepath.FromSlash("symTest/symTest2/symTmpfile")
+
+	if err := ioutil.WriteFile(p, []byte("abc"), 0400); err != nil {
 		t.Errorf("Could not write symTmpfile: %s", err)
 	}
 
@@ -73,7 +79,7 @@ func TestSymlinkToFolder(t *testing.T) {
 	}
 
 	expected := map[string]interface{}{
-		"symTest/symTest2/symTmpfile": map[string]interface{}{
+		p: map[string]interface{}{
 			"sha256": "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
 		},
 	}

--- a/in_toto/runlib_test.go
+++ b/in_toto/runlib_test.go
@@ -43,7 +43,7 @@ func TestSymlinkToFile(t *testing.T) {
 			"sha256": "52947cb78b91ad01fe81cd6aef42d1f6817e92b9e6936c1e5aabb7c98514f355",
 		},
 	}
-	result, err := RecordArtifacts([]string{"foo.tar.gz.sym"}, 0)
+	result, err := RecordArtifacts([]string{"foo.tar.gz.sym"})
 	if !reflect.DeepEqual(result, expected) {
 		t.Errorf("RecordArtifacts returned '(%s, %s)', expected '(%s, nil)'",
 			result, err, expected)
@@ -82,7 +82,7 @@ func TestIndirectSymlinkCycles(t *testing.T) {
 	}
 
 	// provoke "symlink cycle detected" error
-	_, err = RecordArtifacts([]string{"symTestA/linkToB.sym", "symTestB/linkToA.sym", "foo.tar.gz"}, 0)
+	_, err = RecordArtifacts([]string{"symTestA/linkToB.sym", "symTestB/linkToA.sym", "foo.tar.gz"})
 	if !errors.Is(err, ErrSymCycle) {
 		t.Errorf("We expected: %s, we got: %s", ErrSymCycle, err)
 	}
@@ -125,7 +125,7 @@ func TestSymlinkToFolder(t *testing.T) {
 		t.Errorf("Could not write symTmpfile: %s", err)
 	}
 
-	result, err := RecordArtifacts([]string{"symTmpfile.sym"}, 0)
+	result, err := RecordArtifacts([]string{"symTmpfile.sym"})
 	if err != nil {
 		t.Error(err)
 	}
@@ -177,7 +177,7 @@ func TestSymlinkCycle(t *testing.T) {
 	}
 
 	// provoke "symlink cycle detected" error
-	_, err = RecordArtifacts([]string{"symlinkCycle/symCycle.sym", "foo.tar.gz"}, 0)
+	_, err = RecordArtifacts([]string{"symlinkCycle/symCycle.sym", "foo.tar.gz"})
 	if !errors.Is(err, ErrSymCycle) {
 		t.Errorf("We expected: %s, we got: %s", ErrSymCycle, err)
 	}
@@ -200,7 +200,7 @@ func TestRecordArtifacts(t *testing.T) {
 		t.Errorf("Could not write tmpfile: %s", err)
 	}
 	result, err := RecordArtifacts([]string{"foo.tar.gz",
-		"demo.layout.template", "tmpdir/tmpfile"}, 0)
+		"demo.layout.template", "tmpdir/tmpfile"})
 	expected := map[string]interface{}{
 		"foo.tar.gz": map[string]interface{}{
 			"sha256": "52947cb78b91ad01fe81cd6aef42d1f6817e92b9e6936c1e5aabb7c98514f355",
@@ -221,7 +221,7 @@ func TestRecordArtifacts(t *testing.T) {
 	}
 
 	// Test error by recording nonexistent artifact
-	result, err = RecordArtifacts([]string{"file-does-not-exist"}, 0)
+	result, err = RecordArtifacts([]string{"file-does-not-exist"})
 	if !os.IsNotExist(err) {
 		t.Errorf("RecordArtifacts returned '(%s, %s)', expected '(nil, %s)'",
 			result, err, os.ErrNotExist)


### PR DESCRIPTION
*Please fill in the fields below to submit a pull request.  The more
information that is provided, the better.*

**Fixes issue #**:
https://github.com/in-toto/in-toto-golang/issues/32
as well as PR https://github.com/in-toto/in-toto-golang/pull/37

**Description of pull request**:
We are using filepath.EvalSymlinks() here, because it will
give us the last element in a symlink chain.
Therefore we don't need to worry about stack size
or recursion cycles.

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


