### PR TITLE
Remove symlink item in README not-supported list

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,5 +36,4 @@ we will try to provide them as soon as possible!
   cannot be used to create signed evidence (link metadata) for steps in a
   layout.*
 * [Hashing algorithms, other than `sha256` (in artifact recording)](https://github.com/in-toto/in-toto-golang/issues/31)
-* [Symbolic links (in artifact recording)](https://github.com/in-toto/in-toto-golang/issues/32)
 * [Exclude patterns (in artifact recording)](https://github.com/in-toto/in-toto-golang/issues/33)


### PR DESCRIPTION

**Fixes issue #**:
None

**Description of pull request**:

Symlink walk support in RecordArtifacts was kindly added by
@shibumi in #55, fixing #32. This commit removes the note that it
is not yet supported.





**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


