### PR TITLE
use Go 1.15's ecdsa.Sign/VerifyASN1 methods

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.14.x]
+        go-version: [1.15.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/in-toto/in-toto-golang
 
-go 1.14
+go 1.15
 
 require (
 	github.com/shibumi/go-pathspec v1.2.0

--- a/in_toto/in_toto_test.go
+++ b/in_toto/in_toto_test.go
@@ -52,5 +52,5 @@ func TestMain(m *testing.M) {
 	}(testDir)
 
 	// Run tests
-	os.Exit(m.Run())
+	m.Run()
 }

--- a/in_toto/keylib_test.go
+++ b/in_toto/keylib_test.go
@@ -1,7 +1,6 @@
 package in_toto
 
 import (
-	"encoding/asn1"
 	"errors"
 	"os"
 	"testing"
@@ -388,7 +387,7 @@ func TestVerifySignatureErrors(t *testing.T) {
 		}, Signature{
 			KeyId: "invalid",
 			Sig:   "BAAAAAAD",
-		}, asn1.SyntaxError{Msg: "truncated tag or length"},
+		}, ErrInvalidSignature,
 		},
 		{
 			"ed25519 with invalid public key", Key{

--- a/in_toto/model.go
+++ b/in_toto/model.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"math/big"
 	"os"
 	"reflect"
 	"regexp"
@@ -15,16 +14,6 @@ import (
 	"strings"
 	"time"
 )
-
-/*
-EcdsaSignature is being used for constructing an ASN.1 marshalled ecdsa
-signature. We use *big.Int here and not big.Int, because all functions
-on big.Int are pointer receivers. `asn1:"tag2"` refers to ASN.1 INTEGER.
-*/
-type EcdsaSignature struct {
-	R *big.Int `asn1:"tag:2"`
-	S *big.Int `asn1:"tag:2"`
-}
 
 /*
 KeyVal contains the actual values of a key, as opposed to key metadata such as


### PR DESCRIPTION
With Go 1.15, crypto/ecdsa supports
ecdsa.SignASN1 and ecdsa.VerifyASN1
methods. These methods are easier to use,
because they return a signature encoded
in ASN1. In the past we did this we did
this manually. Using the stdlib
should be less toilsome and less error-prone.

*Please fill in the fields below to submit a pull request.  The more
information that is provided, the better.*

**Fixes issue #**:

https://github.com/in-toto/in-toto-golang/issues/64 and #60 

**Description of pull request**:

This is going to add the new ecdsa ASN1 methods + fixes the cleanup in our testMain method.

**Please verify and check that the pull request fulfills the following
requirements**:

- [X] Tests have been added for the bug fix or new feature
- [X] Docs have been added for the bug fix or new feature


