### PR TITLE
Move subsetCheck to Set Interface

### DIFF
--- a/in_toto/keylib.go
+++ b/in_toto/keylib.go
@@ -51,8 +51,8 @@ getSupportedKeyIdHashAlgorithms returns a string slice of supported
 keyIdHashAlgorithms. We need to use this function instead of a constant,
 because Go does not support global constant slices.
 */
-func getSupportedKeyIdHashAlgorithms() []string {
-	return []string{"sha256", "sha512"}
+func getSupportedKeyIdHashAlgorithms() Set {
+	return NewSet("sha256", "sha512")
 }
 
 /*

--- a/in_toto/model.go
+++ b/in_toto/model.go
@@ -242,7 +242,8 @@ func validateKey(key Key) error {
 	}
 	// only check for supported keyIdHashAlgorithms, if the variable has been set
 	if key.KeyIdHashAlgorithms != nil {
-		if !subsetCheck(key.KeyIdHashAlgorithms, getSupportedKeyIdHashAlgorithms()) {
+		supportedKeyIdHashAlgorithms := getSupportedKeyIdHashAlgorithms()
+		if !supportedKeyIdHashAlgorithms.IsSubSet(NewSet(key.KeyIdHashAlgorithms...)) {
 			return fmt.Errorf("%w: %#v, supported are: %#v", ErrUnsupportedKeyIdHashAlgorithms, key.KeyIdHashAlgorithms, getSupportedKeyIdHashAlgorithms())
 		}
 	}

--- a/in_toto/util.go
+++ b/in_toto/util.go
@@ -131,26 +131,19 @@ func InterfaceKeyStrings(m map[string]interface{}) []string {
 }
 
 /*
-subsetCheck checks if all strings in a slice of strings
-can be found in a superset slice of strings.
+IsSubSet checks if the parameter subset is a
+subset of the superset s.
 */
-func subsetCheck(subset []string, superset []string) bool {
-	// TODO: This function might be better as addition
-	// to our Set interface.
-	// We use a Go label here to break out to the outer loop
-OUTER:
-	for _, sub := range subset {
-		for _, super := range superset {
-			if sub == super {
-				continue OUTER
-			}
-		}
-		// If we cannot find a substring from subset in the superset
-		// we return false. In terms of keyIdHashAlgorithms for example
-		// this would mean, that we have an unsupported hash algorithm
-		// in our keyIdHashAlgorithm slice.
+func (s Set) IsSubSet(subset Set) bool {
+	if len(subset) > len(s) {
 		return false
 	}
-	// return true if all substrings can be found in the superset
+	for key, _ := range subset {
+		if s.Has(key) {
+			continue
+		} else {
+			return false
+		}
+	}
 	return true
 }

--- a/in_toto/util_test.go
+++ b/in_toto/util_test.go
@@ -96,15 +96,15 @@ func TestInterfaceKeyStrings(t *testing.T) {
 func TestSubsetCheck(t *testing.T) {
 	tables := []struct {
 		subset   []string
-		superset []string
+		superset Set
 		result   bool
 	}{
-		{[]string{"sha256"}, []string{"sha256", "sha512"}, true},
-		{[]string{"sha512"}, []string{"sha256"}, false},
-		{[]string{"sha256", "sha512"}, []string{"sha128", "sha256", "sha512"}, true},
+		{[]string{"sha256"}, NewSet("sha256", "sha512"), true},
+		{[]string{"sha512"}, NewSet("sha256"), false},
+		{[]string{"sha256", "sha512"}, NewSet("sha128", "sha256", "sha512"), true},
 	}
 	for _, table := range tables {
-		result := subsetCheck(table.subset, table.superset)
+		result := table.superset.IsSubSet(NewSet(table.subset...))
 		if table.result != result {
 			t.Errorf("result mismatch for: %#v, %#v, got: %t, should have got: %t", table.subset, table.superset, result, table.result)
 		}


### PR DESCRIPTION
**Fixes issue #**:
https://github.com/in-toto/in-toto-golang/issues/66

**Description of pull request**:
This Requests fulfils issue #66 and moves the subsetCheck function into our Set interface.

**Please verify and check that the pull request fulfills the following
requirements**:

- [X] Tests have been added for the bug fix or new feature
- [X] Docs have been added for the bug fix or new feature


