### PR TITLE
Never use pemBytes directly

### DIFF
--- a/in_toto/keylib.go
+++ b/in_toto/keylib.go
@@ -44,6 +44,9 @@ const (
 	ecdsaSha2nistp256     string = "ecdsa-sha2-nistp256"
 	ecdsaSha2nistp384     string = "ecdsa-sha2-nistp384"
 	ed25519Scheme         string = "ed25519"
+	pemPublicKey          string = "PUBLIC KEY"
+	pemPrivateKey         string = "PRIVATE KEY"
+	pemRSAPrivateKey      string = "PRIVATE RSA KEY"
 )
 
 /*
@@ -146,23 +149,23 @@ func (k *Key) setKeyComponents(pubKeyBytes []byte, privateKeyBytes []byte, keyTy
 	case rsaKeyType:
 		if len(privateKeyBytes) > 0 {
 			k.KeyVal = KeyVal{
-				Private: strings.TrimSpace(string(generatePEMBlock(privateKeyBytes, "PRIVATE RSA KEY"))),
-				Public:  strings.TrimSpace(string(generatePEMBlock(pubKeyBytes, "PUBLIC KEY"))),
+				Private: strings.TrimSpace(string(generatePEMBlock(privateKeyBytes, pemRSAPrivateKey))),
+				Public:  strings.TrimSpace(string(generatePEMBlock(pubKeyBytes, pemPublicKey))),
 			}
 		} else {
 			k.KeyVal = KeyVal{
-				Public: strings.TrimSpace(string(generatePEMBlock(pubKeyBytes, "PUBLIC KEY"))),
+				Public: strings.TrimSpace(string(generatePEMBlock(pubKeyBytes, pemPublicKey))),
 			}
 		}
 	case ecdsaKeyType:
 		if len(privateKeyBytes) > 0 {
 			k.KeyVal = KeyVal{
-				Private: strings.TrimSpace(string(generatePEMBlock(privateKeyBytes, "PRIVATE KEY"))),
-				Public:  strings.TrimSpace(string(generatePEMBlock(pubKeyBytes, "PUBLIC KEY"))),
+				Private: strings.TrimSpace(string(generatePEMBlock(privateKeyBytes, pemPrivateKey))),
+				Public:  strings.TrimSpace(string(generatePEMBlock(pubKeyBytes, pemPublicKey))),
 			}
 		} else {
 			k.KeyVal = KeyVal{
-				Public: strings.TrimSpace(string(generatePEMBlock(pubKeyBytes, "PUBLIC KEY"))),
+				Public: strings.TrimSpace(string(generatePEMBlock(pubKeyBytes, pemPublicKey))),
 			}
 		}
 	case ed25519KeyType:

--- a/in_toto/model.go
+++ b/in_toto/model.go
@@ -106,7 +106,8 @@ func validateKeyVal(key Key) error {
 			}
 		}
 	case rsaKeyType, ecdsaKeyType:
-		parsedKey, err := decodeAndParse([]byte(key.KeyVal.Public))
+		// We do not need the pemData here, so we can throw it away via '_'
+		_, parsedKey, err := decodeAndParse([]byte(key.KeyVal.Public))
 		if err != nil {
 			return err
 		}
@@ -115,7 +116,8 @@ func validateKeyVal(key Key) error {
 			return err
 		}
 		if key.KeyVal.Private != "" {
-			parsedKey, err := decodeAndParse([]byte(key.KeyVal.Private))
+			// We do not need the pemData here, so we can throw it away via '_'
+			_, parsedKey, err := decodeAndParse([]byte(key.KeyVal.Private))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
**Fixes issue #**:

https://github.com/in-toto/in-toto-golang/issues/75

**Description of pull request**:

We cannot use the pemBytes directly, because there might be different
line separators on different operating systems (CRLF vs LF).
Therefore we are always decoding the pemBytes now and we are only
working with decoded key bytes. These formats are operating system independent.

**Please verify and check that the pull request fulfills the following
requirements**:

- [X] Tests have been added for the bug fix or new feature
- [X] Docs have been added for the bug fix or new feature


