### PR TITLE
add godoc reference badge + go report

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # In-toto Go implementation
-[![build](https://github.com/in-toto/in-toto-golang/workflows/build/badge.svg)](https://github.com/in-toto/in-toto-golang/actions?query=workflow%3Abuild) [![Coverage Status](https://coveralls.io/repos/github/in-toto/in-toto-golang/badge.svg)](https://coveralls.io/github/in-toto/in-toto-golang)
+[![build](https://github.com/in-toto/in-toto-golang/workflows/build/badge.svg)](https://github.com/in-toto/in-toto-golang/actions?query=workflow%3Abuild) [![Coverage Status](https://coveralls.io/repos/github/in-toto/in-toto-golang/badge.svg)](https://coveralls.io/github/in-toto/in-toto-golang) [![PkgGoDev](https://pkg.go.dev/badge/github.com/in-toto/in-toto-golang)](https://pkg.go.dev/github.com/in-toto/in-toto-golang) [![Go Report Card](https://goreportcard.com/badge/github.com/in-toto/in-toto-golang)](https://goreportcard.com/report/github.com/in-toto/in-toto-golang)
 
 
 Go implementation of the 


### PR DESCRIPTION
**Fixes issue #**:
none

**Description of pull request**:
This commit adds two new badges to the README.md file.
The Go reference badge links directly to the API documentation
at pkg.go.dev and the go report adds statistics for additional
code metrics like `go vet`, mispelled words, etc.

**Please verify and check that the pull request fulfills the following
requirements**:

- [X] Tests have been added for the bug fix or new feature
- [X] Docs have been added for the bug fix or new feature


