### PR TITLE
Add a "LoadKeyReader" method to allow loading a key from memory.

### DIFF
--- a/in_toto/keylib.go
+++ b/in_toto/keylib.go
@@ -12,10 +12,12 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"golang.org/x/crypto/ed25519"
+	"io"
 	"io/ioutil"
 	"os"
 	"strings"
+
+	"golang.org/x/crypto/ed25519"
 )
 
 // ErrFailedPEMParsing gets returned when PKCS1, PKCS8 or PKIX key parsing fails
@@ -288,8 +290,16 @@ func (k *Key) LoadKey(path string, scheme string, keyIdHashAlgorithms []string) 
 			err = closeErr
 		}
 	}()
+	return k.LoadKeyReader(pemFile, scheme, keyIdHashAlgorithms)
+}
+
+// LoadKeyReader loads the key from a supplied reader. The logic matches LoadKey otherwise.
+func (k *Key) LoadKeyReader(r io.Reader, scheme string, keyIdHashAlgorithms []string) error {
+	if r == nil {
+		return ErrNoPEMBlock
+	}
 	// Read key bytes
-	pemBytes, err := ioutil.ReadAll(pemFile)
+	pemBytes, err := ioutil.ReadAll(r)
 	if err != nil {
 		return err
 	}

--- a/in_toto/keylib_test.go
+++ b/in_toto/keylib_test.go
@@ -37,6 +37,15 @@ func TestLoadKey(t *testing.T) {
 	}
 }
 
+// TestLoadKeyReader makes sure, that our LoadKeyReader function loads keys correctly
+// and that the key IDs of private and public key match.
+func TestLoadKeyReader(t *testing.T) {
+	var key Key
+	if err := key.LoadKeyReader(nil, "ed25519", []string{"sha256", "sha512"}); err != ErrNoPEMBlock {
+		t.Errorf("unexpected error loading key: %s", err)
+	}
+}
+
 // TestValidSignatures utilizes our TestLoadKey function, but does not check the expected keyID.
 // Instead the test function generates a signature via GenerateSignature() over valid data and verifies the data
 // via ValidateSignature() with the from the private key extracted public key. We know that our extracted public key


### PR DESCRIPTION
**Description of pull request**:

LoadKey requires the key to be suppled on disk. It's a bit more idiomatic
in Go to also allow using readers where possible.


**Please verify and check that the pull request fulfills the following
requirements**:

- [] Tests have been added for the bug fix or new feature
- [X] Docs have been added for the bug fix or new feature


