### PR TITLE
fix: set correct go version and module path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
-module github.com/shibumi/in-toto-golang
+module github.com/in-toto/in-toto-golang
 
-go 1.15
+go 1.14
 
 require (
 	github.com/shibumi/go-pathspec v1.2.0


### PR DESCRIPTION
This fixes my mistake from my previous PR and resets
the go module and the go version to the correct ones.

*Please fill in the fields below to submit a pull request.  The more
information that is provided, the better.*

**Fixes issue #**:

This fixes the wrong go.mod from my last PR

**Description of pull request**:

Set Go 1.14 and correct module path

**Please verify and check that the pull request fulfills the following
requirements**:

- [X] Tests have been added for the bug fix or new feature
- [X] Docs have been added for the bug fix or new feature


