### PR TITLE
Use crypto/ed25519 instead of golang.org/x/crypto/ed25519

### DIFF
--- a/in_toto/keylib.go
+++ b/in_toto/keylib.go
@@ -3,6 +3,7 @@ package in_toto
 import (
 	"crypto"
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha256"
@@ -15,8 +16,6 @@ import (
 	"io/ioutil"
 	"os"
 	"strings"
-
-	"golang.org/x/crypto/ed25519"
 )
 
 // ErrFailedPEMParsing gets returned when PKCS1, PKCS8 or PKIX key parsing fails


### PR DESCRIPTION
**Fixes issue #**: None

**Description of pull request**:

Replaces an import of `golang.org/x/crypto/ed25519` with `crypto/ed25519`. The former was used because AppVeyor had some issues when ed25519 support was first added, but we've moved on from AppVeyor since then. Link: https://github.com/in-toto/in-toto-golang/pull/48#pullrequestreview-311134840

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


