### PR TITLE
Add misc fixes based on go lint

### DIFF
--- a/in_toto/canonicaljson.go
+++ b/in_toto/canonicaljson.go
@@ -11,24 +11,24 @@ import (
 )
 
 /*
-_encodeCanonicalString is a helper function to canonicalize the passed string
+encodeCanonicalString is a helper function to canonicalize the passed string
 according to the OLPC canonical JSON specification for strings (see
 http://wiki.laptop.org/go/Canonical_JSON).  String canonicalization consists of
 escaping backslashes ("\") and double quotes (") and wrapping the resulting
 string in double quotes (").
 */
-func _encodeCanonicalString(s string) string {
+func encodeCanonicalString(s string) string {
 	re := regexp.MustCompile(`([\"\\])`)
 	return fmt.Sprintf("\"%s\"", re.ReplaceAllString(s, "\\$1"))
 }
 
 /*
-_encodeCanonical is a helper function to recursively canonicalize the passed
+encodeCanonical is a helper function to recursively canonicalize the passed
 object according to the OLPC canonical JSON specification (see
 http://wiki.laptop.org/go/Canonical_JSON) and write it to the passed
 *bytes.Buffer.  If canonicalization fails it returns an error.
 */
-func _encodeCanonical(obj interface{}, result *bytes.Buffer) (err error) {
+func encodeCanonical(obj interface{}, result *bytes.Buffer) (err error) {
 	// Since this function is called recursively, we use panic if an error occurs
 	// and recover in a deferred function, which is always called before
 	// returning. There we set the error that is returned eventually.
@@ -40,7 +40,7 @@ func _encodeCanonical(obj interface{}, result *bytes.Buffer) (err error) {
 
 	switch objAsserted := obj.(type) {
 	case string:
-		result.WriteString(_encodeCanonicalString(objAsserted))
+		result.WriteString(encodeCanonicalString(objAsserted))
 
 	case bool:
 		if objAsserted {
@@ -68,7 +68,7 @@ func _encodeCanonical(obj interface{}, result *bytes.Buffer) (err error) {
 	case []interface{}:
 		result.WriteString("[")
 		for i, val := range objAsserted {
-			if err := _encodeCanonical(val, result); err != nil {
+			if err := encodeCanonical(val, result); err != nil {
 				return err
 			}
 			if i < (len(objAsserted) - 1) {
@@ -93,10 +93,10 @@ func _encodeCanonical(obj interface{}, result *bytes.Buffer) (err error) {
 			// Note: `key` must be a `string` (see `case map[string]interface{}`) and
 			// canonicalization of strings cannot err out (see `case string`), thus
 			// no error handling is needed here.
-			_encodeCanonical(key, result)
+			encodeCanonical(key, result)
 
 			result.WriteString(":")
-			if err := _encodeCanonical(objAsserted[key], result); err != nil {
+			if err := encodeCanonical(objAsserted[key], result); err != nil {
 				return err
 			}
 			if i < (len(mapKeys) - 1) {
@@ -137,7 +137,7 @@ func EncodeCanonical(obj interface{}) ([]byte, error) {
 
 	// Create a buffer and write the canonicalized JSON bytes to it
 	var result bytes.Buffer
-	if err := _encodeCanonical(jsonMap, &result); err != nil {
+	if err := encodeCanonical(jsonMap, &result); err != nil {
 		return nil, err
 	}
 

--- a/in_toto/canonicaljson_test.go
+++ b/in_toto/canonicaljson_test.go
@@ -14,8 +14,8 @@ func TestEncodeCanonical(t *testing.T) {
 				Private: "priv",
 				Public:  "pub",
 			},
-			KeyIdHashAlgorithms: []string{"hash"},
-			KeyId:               "id",
+			KeyIDHashAlgorithms: []string{"hash"},
+			KeyID:               "id",
 			KeyType:             "type",
 			Scheme:              "scheme",
 		},
@@ -63,17 +63,17 @@ func TestEncodeCanonicalErr(t *testing.T) {
 	}
 }
 
-func Test_encodeCanonical(t *testing.T) {
+func TestencodeCanonical(t *testing.T) {
 	expectedError := "Can't canonicalize"
 
 	objects := []interface{}{
-		Test_encodeCanonical,
-		[]interface{}{Test_encodeCanonical},
+		TestencodeCanonical,
+		[]interface{}{TestencodeCanonical},
 	}
 
 	for i := 0; i < len(objects); i++ {
 		var result bytes.Buffer
-		err := _encodeCanonical(objects[i], &result)
+		err := encodeCanonical(objects[i], &result)
 		if err == nil || !strings.Contains(err.Error(), expectedError) {
 			t.Errorf("EncodeCanonical returned '%s', expected '%s' error",
 				err, expectedError)

--- a/in_toto/examples_test.go
+++ b/in_toto/examples_test.go
@@ -28,7 +28,7 @@ func ExampleInTotoVerify() {
 		fmt.Printf("Unable to load public key: %s", err)
 	}
 	var layoutKeys = map[string]Key{
-		pubKey.KeyId: pubKey,
+		pubKey.KeyID: pubKey,
 	}
 
 	// Perform in-toto software supply chain verification, using the provided

--- a/in_toto/keylib.go
+++ b/in_toto/keylib.go
@@ -48,11 +48,11 @@ const (
 )
 
 /*
-getSupportedKeyIdHashAlgorithms returns a string slice of supported
-keyIdHashAlgorithms. We need to use this function instead of a constant,
+getSupportedKeyIDHashAlgorithms returns a string slice of supported
+KeyIDHashAlgorithms. We need to use this function instead of a constant,
 because Go does not support global constant slices.
 */
-func getSupportedKeyIdHashAlgorithms() Set {
+func getSupportedKeyIDHashAlgorithms() Set {
 	return NewSet("sha256", "sha512")
 }
 
@@ -93,14 +93,14 @@ there will be an error.
 func (k *Key) generateKeyID() error {
 	// Create partial key map used to create the keyid
 	// Unfortunately, we can't use the Key object because this also carries
-	// yet unwanted fields, such as KeyId and KeyVal.Private and therefore
-	// produces a different hash. We generate the keyId exactly as we do in
+	// yet unwanted fields, such as KeyID and KeyVal.Private and therefore
+	// produces a different hash. We generate the keyID exactly as we do in
 	// the securesystemslib  to keep interoperability between other in-toto
 	// implementations.
 	var keyToBeHashed = map[string]interface{}{
 		"keytype":               k.KeyType,
 		"scheme":                k.Scheme,
-		"keyid_hash_algorithms": k.KeyIdHashAlgorithms,
+		"keyid_hash_algorithms": k.KeyIDHashAlgorithms,
 		"keyval": map[string]string{
 			"public": k.KeyVal.Public,
 		},
@@ -109,9 +109,9 @@ func (k *Key) generateKeyID() error {
 	if err != nil {
 		return err
 	}
-	// calculate sha256 and return string representation of keyId
+	// calculate sha256 and return string representation of keyID
 	keyHashed := sha256.Sum256(keyCanonical)
-	k.KeyId = fmt.Sprintf("%x", keyHashed)
+	k.KeyID = fmt.Sprintf("%x", keyHashed)
 	err = validateKey(*k)
 	if err != nil {
 		return err
@@ -141,7 +141,7 @@ Furthermore it makes sure to remove any trailing and leading whitespaces or newl
 We treat key types differently for interoperability reasons to the in-toto python
 implementation and the securesystemslib.
 */
-func (k *Key) setKeyComponents(pubKeyBytes []byte, privateKeyBytes []byte, keyType string, scheme string, keyIdHashAlgorithms []string) error {
+func (k *Key) setKeyComponents(pubKeyBytes []byte, privateKeyBytes []byte, keyType string, scheme string, KeyIDHashAlgorithms []string) error {
 	// assume we have a privateKey if the key size is bigger than 0
 	switch keyType {
 	case rsaKeyType:
@@ -182,7 +182,7 @@ func (k *Key) setKeyComponents(pubKeyBytes []byte, privateKeyBytes []byte, keyTy
 	}
 	k.KeyType = keyType
 	k.Scheme = scheme
-	k.KeyIdHashAlgorithms = keyIdHashAlgorithms
+	k.KeyIDHashAlgorithms = KeyIDHashAlgorithms
 	if err := k.generateKeyID(); err != nil {
 		return err
 	}
@@ -276,7 +276,7 @@ On success it will return nil. The following errors can happen:
 	* errors while marshalling
 	* unsupported key types
 */
-func (k *Key) LoadKey(path string, scheme string, keyIdHashAlgorithms []string) error {
+func (k *Key) LoadKey(path string, scheme string, KeyIDHashAlgorithms []string) error {
 	pemFile, err := os.Open(path)
 	if err != nil {
 		return err
@@ -286,11 +286,11 @@ func (k *Key) LoadKey(path string, scheme string, keyIdHashAlgorithms []string) 
 			err = closeErr
 		}
 	}()
-	return k.LoadKeyReader(pemFile, scheme, keyIdHashAlgorithms)
+	return k.LoadKeyReader(pemFile, scheme, KeyIDHashAlgorithms)
 }
 
 // LoadKeyReader loads the key from a supplied reader. The logic matches LoadKey otherwise.
-func (k *Key) LoadKeyReader(r io.Reader, scheme string, keyIdHashAlgorithms []string) error {
+func (k *Key) LoadKeyReader(r io.Reader, scheme string, KeyIDHashAlgorithms []string) error {
 	if r == nil {
 		return ErrNoPEMBlock
 	}
@@ -313,7 +313,7 @@ func (k *Key) LoadKeyReader(r io.Reader, scheme string, keyIdHashAlgorithms []st
 		if err != nil {
 			return err
 		}
-		if err := k.setKeyComponents(pubKeyBytes, []byte{}, rsaKeyType, scheme, keyIdHashAlgorithms); err != nil {
+		if err := k.setKeyComponents(pubKeyBytes, []byte{}, rsaKeyType, scheme, KeyIDHashAlgorithms); err != nil {
 			return err
 		}
 	case *rsa.PrivateKey:
@@ -323,16 +323,16 @@ func (k *Key) LoadKeyReader(r io.Reader, scheme string, keyIdHashAlgorithms []st
 		if err != nil {
 			return err
 		}
-		if err := k.setKeyComponents(pubKeyBytes, pemData.Bytes, rsaKeyType, scheme, keyIdHashAlgorithms); err != nil {
+		if err := k.setKeyComponents(pubKeyBytes, pemData.Bytes, rsaKeyType, scheme, KeyIDHashAlgorithms); err != nil {
 			return err
 		}
 	case ed25519.PublicKey:
-		if err := k.setKeyComponents(key.(ed25519.PublicKey), []byte{}, ed25519KeyType, scheme, keyIdHashAlgorithms); err != nil {
+		if err := k.setKeyComponents(key.(ed25519.PublicKey), []byte{}, ed25519KeyType, scheme, KeyIDHashAlgorithms); err != nil {
 			return err
 		}
 	case ed25519.PrivateKey:
 		pubKeyBytes := key.(ed25519.PrivateKey).Public()
-		if err := k.setKeyComponents(pubKeyBytes.(ed25519.PublicKey), key.(ed25519.PrivateKey), ed25519KeyType, scheme, keyIdHashAlgorithms); err != nil {
+		if err := k.setKeyComponents(pubKeyBytes.(ed25519.PublicKey), key.(ed25519.PrivateKey), ed25519KeyType, scheme, KeyIDHashAlgorithms); err != nil {
 			return err
 		}
 	case *ecdsa.PrivateKey:
@@ -340,7 +340,7 @@ func (k *Key) LoadKeyReader(r io.Reader, scheme string, keyIdHashAlgorithms []st
 		if err != nil {
 			return err
 		}
-		if err := k.setKeyComponents(pubKeyBytes, pemData.Bytes, ecdsaKeyType, scheme, keyIdHashAlgorithms); err != nil {
+		if err := k.setKeyComponents(pubKeyBytes, pemData.Bytes, ecdsaKeyType, scheme, KeyIDHashAlgorithms); err != nil {
 			return err
 		}
 	case *ecdsa.PublicKey:
@@ -348,7 +348,7 @@ func (k *Key) LoadKeyReader(r io.Reader, scheme string, keyIdHashAlgorithms []st
 		if err != nil {
 			return err
 		}
-		if err := k.setKeyComponents(pubKeyBytes, []byte{}, ecdsaKeyType, scheme, keyIdHashAlgorithms); err != nil {
+		if err := k.setKeyComponents(pubKeyBytes, []byte{}, ecdsaKeyType, scheme, KeyIDHashAlgorithms); err != nil {
 			return err
 		}
 	default:
@@ -456,7 +456,7 @@ func GenerateSignature(signable []byte, key Key) (Signature, error) {
 		panic("unexpected Error in GenerateSignature function")
 	}
 	signature.Sig = hex.EncodeToString(signatureBuffer)
-	signature.KeyId = key.KeyId
+	signature.KeyID = key.KeyID
 	return signature, nil
 }
 

--- a/in_toto/keylib_test.go
+++ b/in_toto/keylib_test.go
@@ -34,8 +34,8 @@ func TestLoadKey(t *testing.T) {
 		if err != nil {
 			t.Errorf("failed key.LoadKey() for %s %s. Error: %s", table.name, table.path, err)
 		}
-		if table.expectedKeyID != key.KeyId {
-			t.Errorf("keyID for %s %s does not match expected keyID: %s. Got keyID: %s", table.name, table.path, table.expectedKeyID, key.KeyId)
+		if table.expectedKeyID != key.KeyID {
+			t.Errorf("keyID for %s %s does not match expected keyID: %s. Got keyID: %s", table.name, table.path, table.expectedKeyID, key.KeyID)
 		}
 	}
 }
@@ -127,7 +127,7 @@ func TestSetKeyComponentsErrors(t *testing.T) {
 		privateKeyBytes     []byte
 		keyType             string
 		scheme              string
-		keyIdHashAlgorithms []string
+		KeyIDHashAlgorithms []string
 		err                 error
 	}{
 		{"test invalid key type", []byte{}, []byte{}, "yolo", "ed25519", []string{"sha512"}, ErrUnsupportedKeyType},
@@ -136,7 +136,7 @@ func TestSetKeyComponentsErrors(t *testing.T) {
 
 	for _, table := range invalidTables {
 		var key Key
-		err := key.setKeyComponents(table.pubkeyBytes, table.privateKeyBytes, table.keyType, table.scheme, table.keyIdHashAlgorithms)
+		err := key.setKeyComponents(table.pubkeyBytes, table.privateKeyBytes, table.keyType, table.scheme, table.KeyIDHashAlgorithms)
 		if !errors.Is(err, table.err) {
 			t.Errorf("'%s' failed, should have: '%s', got: '%s'", table.name, ErrUnsupportedKeyType, err)
 		}
@@ -150,8 +150,8 @@ func TestGenerateSignatureErrors(t *testing.T) {
 		expectedError error
 	}{
 		{"invalid type", Key{
-			KeyId:               "be6371bc627318218191ce0780fd3183cce6c36da02938a477d2e4dfae1804a6",
-			KeyIdHashAlgorithms: []string{"sha512"},
+			KeyID:               "be6371bc627318218191ce0780fd3183cce6c36da02938a477d2e4dfae1804a6",
+			KeyIDHashAlgorithms: []string{"sha512"},
 			KeyType:             "invalid",
 			KeyVal: KeyVal{
 				Private: "-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VwBCIEICmtWWk/6UydYjr7tmVUtPa7JIxHdhaJraSHXr2pSECu\n-----END PRIVATE KEY-----",
@@ -162,8 +162,8 @@ func TestGenerateSignatureErrors(t *testing.T) {
 		},
 		{
 			"public key", Key{
-				KeyId:               "be6371bc627318218191ce0780fd3183cce6c36da02938a477d2e4dfae1804a6",
-				KeyIdHashAlgorithms: []string{"sha512"},
+				KeyID:               "be6371bc627318218191ce0780fd3183cce6c36da02938a477d2e4dfae1804a6",
+				KeyIDHashAlgorithms: []string{"sha512"},
 				KeyType:             "ecdsa",
 				KeyVal: KeyVal{
 					Private: "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAOT5nGyAPlkxJCD00qGf12YnsHGnfe2Z1j+RxyFkbE5w=\n-----END PUBLIC KEY-----",
@@ -174,8 +174,8 @@ func TestGenerateSignatureErrors(t *testing.T) {
 		},
 		{
 			"rsa private key, but wrong key type", Key{
-				KeyId:               "be6371bc627318218191ce0780fd3183cce6c36da02938a477d2e4dfae1804a6",
-				KeyIdHashAlgorithms: []string{"sha256"},
+				KeyID:               "be6371bc627318218191ce0780fd3183cce6c36da02938a477d2e4dfae1804a6",
+				KeyIDHashAlgorithms: []string{"sha256"},
 				KeyType:             "ecdsa",
 				KeyVal: KeyVal{
 					Private: "-----BEGIN RSA PRIVATE KEY-----\nMIIG5QIBAAKCAYEAyCTik98953hKl6+B6n5l8DVIDwDnvrJfpasbJ3+Rw66YcawO\nZinRpMxPTqWBKs7sRop7jqsQNcslUoIZLrXPr3foPHF455TlrqPVfCZiFQ+O4Caf\nxWOB4mL1NddvpFXTEjmUiwFrrL7PcvQKMbYzeUHH4tH9MNzqKWbbJoekBsDpCDIx\np1NbgivGBKwjRGa281sClKgpd0Q0ebl+RTcTvpfZVDbXazQ7VqZkidt7geWq2Bid\nOXZp/cjoXyVneKx/gYiOUv8x94svQMzSEhw2LFMQ04A1KnGn1jxO35/fd6/OW32n\njyWs96RKu9UQVacYHsQfsACPWwmVqgnX/sp5ujlvSDjyfZu7c5yUQ2asYfQPLvnj\nG+u7QcBukGf8hAfVgsezzX9QPiK35BKDgBU/Vk43riJs165TJGYGVuLUhIEhHgiQ\ntwo8pUTJS5npEe5XMDuZoighNdzoWY2nfsBfp8348k6vJtDMB093/t6V9sTGYQcS\nbgKPyEQo5Pk6Wd4ZAgMBAAECggGBAIb8YZiMA2tfNSfy5jNqhoQo223LFYIHOf05\nVvofzwbkdcqM2bVL1SpJ5d9MPr7Jio/VDJpfg3JUjdqFBkj7tJRK0eYaPgoq4XIU\n64JtPM+pi5pgUnfFsi8mwO1MXO7AN7hd/3J1RdLfanjEYS/ADB1nIVI4gIR5KrE7\nvujQqO8pIsI1YEnTLa+wqEA0fSDACfo90pLCjBz1clL6qVAzYmy0a46h4k5ajv7V\nAI/96OHmLYDLsRa1Z60T2K17Q7se0zmHSjfssLQ+d+0zdU5BK8wFn1n2DvCc310T\na0ip+V+YNT0FBtmknTobnr9S688bR8vfBK0q0JsZ1YataGyYS0Rp0RYeEInjKie8\nDIzGuYNRzEjrYMlIOCCY5ybo9mbRiQEQvlSunFAAoKyr8svwU8/e2HV4lXxqDY9v\nKZzxeNYVvX2ZUP3D/uz74VvUWe5fz+ZYmmHVW0erbQC8Cxv2Q6SG/eylcfiNDdLG\narf+HNxcvlJ3v7I2w79tqSbHPcJc1QKBwQD6E/zRYiuJCd0ydnJXPCzZ3dhs/Nz0\ny9QJXg7QyLuHPGEV6r2nIK/Ku3d0NHi/hWglCrg2m8ik7BKaIUjvwVI7M/E3gcZu\ngknmlWjt5QY+LLfQdVgBeqwJdqLHXtw2GAJch6LGSxIcZ5F+1MmqUbfElUJ4h/To\nno6CFGfmAc2n6+PSMWxHT6Oe/rrAFQ2B25Kl9kIrfAUeWhtLm+n0ARXo7wKr63rg\nyJBXwr5Rl3U1NJGnuagQqcS7zDdZ2Glaj1cCgcEAzOIwl5Z0I42vU+2z9e+23Tyc\nHnSyp7AaHLJeuv92T8j7sF8qV1brYQqqzUAGpIGR6OZ9Vj2niPdbtdAQpgcTav+9\nBY9Nyk6YDgsTuN+bQEWsM8VfMUFVUXQAdNFJT6VPO877Fi0PnWhqxVVzr7GuUJFM\nzTUSscsqT40Ht2v1v+qYM4EziPUtUlxUbfuc0RwtfbSpALJG+rpPjvdddQ4Xsdj0\nEIoq1r/0v+vo0Dbpdy63N0iYh9r9yHioiUdCPUgPAoHBAJhKL7260NRFQ4UFiKAD\nLzUF2lSUsGIK9nc15kPS2hCC/oSATTpHt4X4H8iOY7IOJdvY6VGoEMoOUU23U1le\nGxueiBjLWPHXOfXHqvykaebXCKFTtGJCOB4TNxG+fNAcUuPSXZfwA3l0wK/CGYU0\n+nomgzIvaT93v0UL9DGni3vlNPm9yziqEPQ0H7n1mCIqeuXCT413mw5exRyIODK1\nrogJdVEIt+3Hdc9b8tZxK5lZCBJiBy0OlZXfyR1XouDZRQKBwC1++N1gio+ukcVo\nXnL5dTjxkZVtwpJcF6BRt5l8yu/yqHlE2KkmYwRckwsa8Z6sKxN1w1VYQZC3pQTd\nnCTSI2y6N2Y5qUOIalmL+igud1IxZojkhjvwzxpUURmfs9Dc25hjYPxOq03/9t21\nGQhlw1ieu1hCNdGHVPDvV0xSy/J/DKc7RI9gKl1EpXb6zZrdz/g/GtxNuldI8gvE\nQFuS8o4KqD/X/qVLYPURVNSPrQ5LMGI1W7GnXn2a1YoOadYj3wKBwQCh+crvbhDr\njb2ud3CJfdCs5sS5SEKADiUcxiJPcypxhmu+7vhG1Nr6mT0SAYWaA36GDJkU7/Oo\nvoal+uigbOt/UugS1nQYnEzDRkTidQMm1gXVNcWRTBFTKwRP/Gd6yOp9BUHJlFCu\nM2q8HYFtmSqOele6xFOAUnHhwVx4QURJYa+S5A603Jm6ETv0+Y6xdHX/02vA+pRt\nlQqaoEO7ScdRrzjgvVxXkEY3nwLcWdM61/RZTL0+be8goDw5cWt+PaA=\n-----END RSA PRIVATE KEY-----",
@@ -186,8 +186,8 @@ func TestGenerateSignatureErrors(t *testing.T) {
 		},
 		{
 			"ecdsa private key, but wrong key type", Key{
-				KeyId:               "be6371bc627318218191ce0780fd3183cce6c36da02938a477d2e4dfae1804a6",
-				KeyIdHashAlgorithms: []string{"sha256"},
+				KeyID:               "be6371bc627318218191ce0780fd3183cce6c36da02938a477d2e4dfae1804a6",
+				KeyIDHashAlgorithms: []string{"sha256"},
 				KeyType:             "rsa",
 				KeyVal: KeyVal{
 					Private: "-----BEGIN PRIVATE KEY-----\nMIHuAgEAMBAGByqGSM49AgEGBSuBBAAjBIHWMIHTAgEBBEIB6fQnV71xKx6kFgJv\nYTMq0ytvWi2mDlYu6aNm1761c1OSInbBxBNb0ligpM65KyaeeRce6JR9eQW6TB6R\n+5pNzvOhgYkDgYYABAFy0CeDAyV/2mY1NqxLLgqEXSxaqM3fM8gYn/ZWzrLnO+1h\nK2QAanID3JuPff1NdhehhL/U1prXdyyaItA5X4ChkQHMTsiS/3HkWRuLR8L22SGs\nB+7KqOeO5ELkqHO5tsy4kvsNrmersCGRQGY6A5V/0JFhP1u1JUvAVVhfRbdQXuu3\nrw==\n-----END PRIVATE KEY-----",
@@ -201,8 +201,8 @@ func TestGenerateSignatureErrors(t *testing.T) {
 		},
 		{
 			"invalid ec private key", Key{
-				KeyId:               "be6371bc627318218191ce0780fd3183cce6c36da02938a477d2e4dfae1804a6",
-				KeyIdHashAlgorithms: []string{"sha256"},
+				KeyID:               "be6371bc627318218191ce0780fd3183cce6c36da02938a477d2e4dfae1804a6",
+				KeyIDHashAlgorithms: []string{"sha256"},
 				KeyType:             "ecdsa",
 				KeyVal: KeyVal{
 					Private: "-----BEGIN EC PRIVATE KEY-----\nMHQCAQEEIJ+y3Jy7kstRBzPmoOfak4t70DsLpFmlZLtppfcP14V3oAcGBSuBBAAK\noUQDQgAELToC9CwqXL8bRTG54QMn3k6dqwI0sDMTOZkriRklJ4HXQbJUWRpv2X8k\nspRECJZDoiOV1OaMMIXjY4XNeoEBmw==\n-----END EC PRIVATE KEY-----\n",
@@ -212,8 +212,8 @@ func TestGenerateSignatureErrors(t *testing.T) {
 			}, ErrFailedPEMParsing,
 		},
 		{"invalid ed25519 private key", Key{
-			KeyId:               "be6371bc627318218191ce0780fd3183cce6c36da02938a477d2e4dfae1804a6",
-			KeyIdHashAlgorithms: []string{"sha512"},
+			KeyID:               "be6371bc627318218191ce0780fd3183cce6c36da02938a477d2e4dfae1804a6",
+			KeyIDHashAlgorithms: []string{"sha512"},
 			KeyType:             "ed25519",
 			KeyVal: KeyVal{
 				Private: "invalid",
@@ -225,8 +225,8 @@ func TestGenerateSignatureErrors(t *testing.T) {
 		{
 			name: "fail parsing RSA key, because of EC private key",
 			key: Key{
-				KeyId:               "be6371bc627318218191ce0780fd3183cce6c36da02938a477d2e4dfae1804a6",
-				KeyIdHashAlgorithms: []string{"sha256"},
+				KeyID:               "be6371bc627318218191ce0780fd3183cce6c36da02938a477d2e4dfae1804a6",
+				KeyIDHashAlgorithms: []string{"sha256"},
 				KeyType:             "rsa",
 				KeyVal: KeyVal{
 					Private: "-----BEGIN EC PRIVATE KEY-----\nMHQCAQEEIJ+y3Jy7kstRBzPmoOfak4t70DsLpFmlZLtppfcP14V3oAcGBSuBBAAK\noUQDQgAELToC9CwqXL8bRTG54QMn3k6dqwI0sDMTOZkriRklJ4HXQbJUWRpv2X8k\nspRECJZDoiOV1OaMMIXjY4XNeoEBmw==\n-----END EC PRIVATE KEY-----\n",
@@ -239,8 +239,8 @@ func TestGenerateSignatureErrors(t *testing.T) {
 		{
 			name: "RSA key, but with ecdsa values",
 			key: Key{
-				KeyId:               "be6371bc627318218191ce0780fd3183cce6c36da02938a477d2e4dfae1804a6",
-				KeyIdHashAlgorithms: []string{"sha256"},
+				KeyID:               "be6371bc627318218191ce0780fd3183cce6c36da02938a477d2e4dfae1804a6",
+				KeyIDHashAlgorithms: []string{"sha256"},
 				KeyType:             "rsa",
 				KeyVal: KeyVal{
 					Private: "-----BEGIN PRIVATE KEY-----\nMIHuAgEAMBAGByqGSM49AgEGBSuBBAAjBIHWMIHTAgEBBEIB6fQnV71xKx6kFgJv\nYTMq0ytvWi2mDlYu6aNm1761c1OSInbBxBNb0ligpM65KyaeeRce6JR9eQW6TB6R\n+5pNzvOhgYkDgYYABAFy0CeDAyV/2mY1NqxLLgqEXSxaqM3fM8gYn/ZWzrLnO+1h\nK2QAanID3JuPff1NdhehhL/U1prXdyyaItA5X4ChkQHMTsiS/3HkWRuLR8L22SGs\nB+7KqOeO5ELkqHO5tsy4kvsNrmersCGRQGY6A5V/0JFhP1u1JUvAVVhfRbdQXuu3\nrw==\n-----END PRIVATE KEY-----\n",
@@ -253,8 +253,8 @@ func TestGenerateSignatureErrors(t *testing.T) {
 		{
 			name: "p224 ecdsa key, but wrong scheme",
 			key: Key{
-				KeyId:               "be6371bc627318218191ce0780fd3183cce6c36da02938a477d2e4dfae1804a6",
-				KeyIdHashAlgorithms: []string{"sha256"},
+				KeyID:               "be6371bc627318218191ce0780fd3183cce6c36da02938a477d2e4dfae1804a6",
+				KeyIDHashAlgorithms: []string{"sha256"},
 				KeyType:             "ecdsa",
 				KeyVal: KeyVal{
 					Private: "-----BEGIN PRIVATE KEY-----\nMHgCAQAwEAYHKoZIzj0CAQYFK4EEACEEYTBfAgEBBBwmUI9xaiYTFQU6OYl/jTnr\n+q2TfUh5LU8U4BrzoTwDOgAEu8hZFOOIyjE5FY71KsUbMOp6OB6e2T4dnFbo0Wrx\nrQFHFtW5Y3kiv6GEVF2mNDllRwJAoFpoF4M=\n-----END PRIVATE KEY-----",
@@ -267,8 +267,8 @@ func TestGenerateSignatureErrors(t *testing.T) {
 		{
 			name: "p384 ecdsa key, but wrong scheme",
 			key: Key{
-				KeyId:               "be6371bc627318218191ce0780fd3183cce6c36da02938a477d2e4dfae1804a6",
-				KeyIdHashAlgorithms: []string{"sha256"},
+				KeyID:               "be6371bc627318218191ce0780fd3183cce6c36da02938a477d2e4dfae1804a6",
+				KeyIDHashAlgorithms: []string{"sha256"},
 				KeyType:             "ecdsa",
 				KeyVal: KeyVal{
 					Private: "-----BEGIN PRIVATE KEY-----\nMIG2AgEAMBAGByqGSM49AgEGBSuBBAAiBIGeMIGbAgEBBDCgpTsIXQ7HswVRgS8Z\nPdSCaGrA87YwUctguSPjvCxy9+sP1791Qx5IYy3RkAzlx8+hZANiAAQ/wpAeooDd\nCGIZBLqOV+hNcmUZMZxfF3Yi2aapT/Ly6vJQ2xedXSdaWgKw5srRcAyswPWJa8dg\nxINXXg8/S9rAs36N9XuWtzkgnDLVoWE+V6shKDB7c6Csol0WSfwsa7Y=\n-----END PRIVATE KEY-----\n",
@@ -281,8 +281,8 @@ func TestGenerateSignatureErrors(t *testing.T) {
 		{
 			name: "p521 ecdsa key, but wrong scheme",
 			key: Key{
-				KeyId:               "be6371bc627318218191ce0780fd3183cce6c36da02938a477d2e4dfae1804a6",
-				KeyIdHashAlgorithms: []string{"sha256"},
+				KeyID:               "be6371bc627318218191ce0780fd3183cce6c36da02938a477d2e4dfae1804a6",
+				KeyIDHashAlgorithms: []string{"sha256"},
 				KeyType:             "ecdsa",
 				KeyVal: KeyVal{
 					Private: "-----BEGIN PRIVATE KEY-----\nMIHuAgEAMBAGByqGSM49AgEGBSuBBAAjBIHWMIHTAgEBBEIB6fQnV71xKx6kFgJv\nYTMq0ytvWi2mDlYu6aNm1761c1OSInbBxBNb0ligpM65KyaeeRce6JR9eQW6TB6R\n+5pNzvOhgYkDgYYABAFy0CeDAyV/2mY1NqxLLgqEXSxaqM3fM8gYn/ZWzrLnO+1h\nK2QAanID3JuPff1NdhehhL/U1prXdyyaItA5X4ChkQHMTsiS/3HkWRuLR8L22SGs\nB+7KqOeO5ELkqHO5tsy4kvsNrmersCGRQGY6A5V/0JFhP1u1JUvAVVhfRbdQXuu3\nrw==\n-----END PRIVATE KEY-----\n",
@@ -311,8 +311,8 @@ func TestVerifySignatureErrors(t *testing.T) {
 	}{
 		{"invalid keytype", Key{}, Signature{}, ErrInvalidHexString},
 		{"invalid rsa/ecdsa public key", Key{
-			KeyId:               "be6371bc627318218191ce0780fd3183cce6c36da02938a477d2e4dfae1804a6",
-			KeyIdHashAlgorithms: nil,
+			KeyID:               "be6371bc627318218191ce0780fd3183cce6c36da02938a477d2e4dfae1804a6",
+			KeyIDHashAlgorithms: nil,
 			KeyType:             "rsa",
 			KeyVal: KeyVal{
 				Private: "",
@@ -323,8 +323,8 @@ func TestVerifySignatureErrors(t *testing.T) {
 		},
 		{
 			"ec public key", Key{
-				KeyId:               "be6371bc627318218191ce0780fd3183cce6c36da02938a477d2e4dfae1804a6",
-				KeyIdHashAlgorithms: []string{"sha256"},
+				KeyID:               "be6371bc627318218191ce0780fd3183cce6c36da02938a477d2e4dfae1804a6",
+				KeyIDHashAlgorithms: []string{"sha256"},
 				KeyType:             "ecdsa",
 				KeyVal: KeyVal{
 					Private: "-----BEGIN EC PRIVATE KEY-----\nMHQCAQEEIJ+y3Jy7kstRBzPmoOfak4t70DsLpFmlZLtppfcP14V3oAcGBSuBBAAK\noUQDQgAELToC9CwqXL8bRTG54QMn3k6dqwI0sDMTOZkriRklJ4HXQbJUWRpv2X8k\nspRECJZDoiOV1OaMMIXjY4XNeoEBmw==\n-----END EC PRIVATE KEY-----",
@@ -335,8 +335,8 @@ func TestVerifySignatureErrors(t *testing.T) {
 		},
 		{
 			"rsa private key as public key", Key{
-				KeyId:               "b7d643dec0a051096ee5d87221b5d91a33daa658699d30903e1cefb90c418401",
-				KeyIdHashAlgorithms: []string{"sha256"},
+				KeyID:               "b7d643dec0a051096ee5d87221b5d91a33daa658699d30903e1cefb90c418401",
+				KeyIDHashAlgorithms: []string{"sha256"},
 				KeyType:             "rsa",
 				KeyVal: KeyVal{
 					Private: "-----BEGIN PUBLIC KEY-----\nMIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEAyCTik98953hKl6+B6n5l\n8DVIDwDnvrJfpasbJ3+Rw66YcawOZinRpMxPTqWBKs7sRop7jqsQNcslUoIZLrXP\nr3foPHF455TlrqPVfCZiFQ+O4CafxWOB4mL1NddvpFXTEjmUiwFrrL7PcvQKMbYz\neUHH4tH9MNzqKWbbJoekBsDpCDIxp1NbgivGBKwjRGa281sClKgpd0Q0ebl+RTcT\nvpfZVDbXazQ7VqZkidt7geWq2BidOXZp/cjoXyVneKx/gYiOUv8x94svQMzSEhw2\nLFMQ04A1KnGn1jxO35/fd6/OW32njyWs96RKu9UQVacYHsQfsACPWwmVqgnX/sp5\nujlvSDjyfZu7c5yUQ2asYfQPLvnjG+u7QcBukGf8hAfVgsezzX9QPiK35BKDgBU/\nVk43riJs165TJGYGVuLUhIEhHgiQtwo8pUTJS5npEe5XMDuZoighNdzoWY2nfsBf\np8348k6vJtDMB093/t6V9sTGYQcSbgKPyEQo5Pk6Wd4ZAgMBAAE=\n-----END PUBLIC KEY-----",
@@ -347,8 +347,8 @@ func TestVerifySignatureErrors(t *testing.T) {
 		},
 		{
 			"invalid ecdsa signature", Key{
-				KeyId:               "d4cd6865653c3aaa9b9eb865e0e45dd8ed58c98cb39c0145d500e009d9817c32",
-				KeyIdHashAlgorithms: []string{"sha256", "sha512"},
+				KeyID:               "d4cd6865653c3aaa9b9eb865e0e45dd8ed58c98cb39c0145d500e009d9817c32",
+				KeyIDHashAlgorithms: []string{"sha256", "sha512"},
 				KeyType:             "ecdsa",
 				KeyVal: KeyVal{
 					Private: "-----BEGIN PRIVATE KEY-----\nMIHuAgEAMBAGByqGSM49AgEGBSuBBAAjBIHWMIHTAgEBBEIB6fQnV71xKx6kFgJv\nYTMq0ytvWi2mDlYu6aNm1761c1OSInbBxBNb0ligpM65KyaeeRce6JR9eQW6TB6R\n+5pNzvOhgYkDgYYABAFy0CeDAyV/2mY1NqxLLgqEXSxaqM3fM8gYn/ZWzrLnO+1h\nK2QAanID3JuPff1NdhehhL/U1prXdyyaItA5X4ChkQHMTsiS/3HkWRuLR8L22SGs\nB+7KqOeO5ELkqHO5tsy4kvsNrmersCGRQGY6A5V/0JFhP1u1JUvAVVhfRbdQXuu3\nrw==\n-----END PRIVATE KEY-----\n",
@@ -356,14 +356,14 @@ func TestVerifySignatureErrors(t *testing.T) {
 				},
 				Scheme: "ecdsa-sha2-nistp521",
 			}, Signature{
-				KeyId: "d4cd6865653c3aaa9b9eb865e0e45dd8ed58c98cb39c0145d500e009d9817c32",
+				KeyID: "d4cd6865653c3aaa9b9eb865e0e45dd8ed58c98cb39c0145d500e009d9817c32",
 				Sig:   "308188824201fae620e5b53e878f2b5cc9b59b8246165ecf8fb3438115dff7ecd567106c707606dceac37ffe5fa531fc03ebe310ce9397d814f1d59c78ddd975123825f976141b824201bca2b5931850d0e8453c41d8a727f136d28a7683bad34c54643978ee066a1eab3403d9dd4e82641cd6325693ee32385aa7a0b5f239f53d8b8b1174f9751e1ee114",
 			}, ErrInvalidSignature,
 		},
 		{
 			"invalid ed25519 signature", Key{
-				KeyId:               "be6371bc627318218191ce0780fd3183cce6c36da02938a477d2e4dfae1804a6",
-				KeyIdHashAlgorithms: []string{"sha256", "sha512"},
+				KeyID:               "be6371bc627318218191ce0780fd3183cce6c36da02938a477d2e4dfae1804a6",
+				KeyIDHashAlgorithms: []string{"sha256", "sha512"},
 				KeyType:             "ed25519",
 				KeyVal: KeyVal{
 					Private: "",
@@ -371,13 +371,13 @@ func TestVerifySignatureErrors(t *testing.T) {
 				},
 				Scheme: "ed25519",
 			}, Signature{
-				KeyId: "be6371bc627318218191ce0780fd3183cce6c36da02938a477d2e4dfae1804a6",
+				KeyID: "be6371bc627318218191ce0780fd3183cce6c36da02938a477d2e4dfae1804a6",
 				Sig:   "BAAAAAAD",
 			}, ErrInvalidSignature,
 		},
 		{"invalid asn1 structure", Key{
-			KeyId:               "be6371bc627318218191ce0780fd3183cce6c36da02938a477d2e4dfae1804a6",
-			KeyIdHashAlgorithms: []string{"sha256"},
+			KeyID:               "be6371bc627318218191ce0780fd3183cce6c36da02938a477d2e4dfae1804a6",
+			KeyIDHashAlgorithms: []string{"sha256"},
 			KeyType:             "ecdsa",
 			KeyVal: KeyVal{
 				Private: "",
@@ -385,14 +385,14 @@ func TestVerifySignatureErrors(t *testing.T) {
 			},
 			Scheme: "ecdsa-sha2-nistp521",
 		}, Signature{
-			KeyId: "invalid",
+			KeyID: "invalid",
 			Sig:   "BAAAAAAD",
 		}, ErrInvalidSignature,
 		},
 		{
 			"ed25519 with invalid public key", Key{
-				KeyId:               "invalid",
-				KeyIdHashAlgorithms: nil,
+				KeyID:               "invalid",
+				KeyIDHashAlgorithms: nil,
 				KeyType:             "ed25519",
 				KeyVal: KeyVal{
 					Private: "invalid",
@@ -403,8 +403,8 @@ func TestVerifySignatureErrors(t *testing.T) {
 		},
 		{
 			"ed25519 with invalid signature", Key{
-				KeyId:               "invalid",
-				KeyIdHashAlgorithms: nil,
+				KeyID:               "invalid",
+				KeyIDHashAlgorithms: nil,
 				KeyType:             "ed25519",
 				KeyVal: KeyVal{
 					Private: "",
@@ -412,15 +412,15 @@ func TestVerifySignatureErrors(t *testing.T) {
 				},
 				Scheme: "ed25519",
 			}, Signature{
-				KeyId: "invalid",
+				KeyID: "invalid",
 				Sig:   "invalid",
 			}, ErrInvalidHexString,
 		},
 		{
 			name: "rsa test invalid signature",
 			key: Key{
-				KeyId:               "b7d643dec0a051096ee5d87221b5d91a33daa658699d30903e1cefb90c418401",
-				KeyIdHashAlgorithms: []string{"sha256"},
+				KeyID:               "b7d643dec0a051096ee5d87221b5d91a33daa658699d30903e1cefb90c418401",
+				KeyIDHashAlgorithms: []string{"sha256"},
 				KeyType:             "rsa",
 				KeyVal: KeyVal{
 					Private: "-----BEGIN RSA PRIVATE KEY-----\nMIIG5QIBAAKCAYEAyCTik98953hKl6+B6n5l8DVIDwDnvrJfpasbJ3+Rw66YcawO\nZinRpMxPTqWBKs7sRop7jqsQNcslUoIZLrXPr3foPHF455TlrqPVfCZiFQ+O4Caf\nxWOB4mL1NddvpFXTEjmUiwFrrL7PcvQKMbYzeUHH4tH9MNzqKWbbJoekBsDpCDIx\np1NbgivGBKwjRGa281sClKgpd0Q0ebl+RTcTvpfZVDbXazQ7VqZkidt7geWq2Bid\nOXZp/cjoXyVneKx/gYiOUv8x94svQMzSEhw2LFMQ04A1KnGn1jxO35/fd6/OW32n\njyWs96RKu9UQVacYHsQfsACPWwmVqgnX/sp5ujlvSDjyfZu7c5yUQ2asYfQPLvnj\nG+u7QcBukGf8hAfVgsezzX9QPiK35BKDgBU/Vk43riJs165TJGYGVuLUhIEhHgiQ\ntwo8pUTJS5npEe5XMDuZoighNdzoWY2nfsBfp8348k6vJtDMB093/t6V9sTGYQcS\nbgKPyEQo5Pk6Wd4ZAgMBAAECggGBAIb8YZiMA2tfNSfy5jNqhoQo223LFYIHOf05\nVvofzwbkdcqM2bVL1SpJ5d9MPr7Jio/VDJpfg3JUjdqFBkj7tJRK0eYaPgoq4XIU\n64JtPM+pi5pgUnfFsi8mwO1MXO7AN7hd/3J1RdLfanjEYS/ADB1nIVI4gIR5KrE7\nvujQqO8pIsI1YEnTLa+wqEA0fSDACfo90pLCjBz1clL6qVAzYmy0a46h4k5ajv7V\nAI/96OHmLYDLsRa1Z60T2K17Q7se0zmHSjfssLQ+d+0zdU5BK8wFn1n2DvCc310T\na0ip+V+YNT0FBtmknTobnr9S688bR8vfBK0q0JsZ1YataGyYS0Rp0RYeEInjKie8\nDIzGuYNRzEjrYMlIOCCY5ybo9mbRiQEQvlSunFAAoKyr8svwU8/e2HV4lXxqDY9v\nKZzxeNYVvX2ZUP3D/uz74VvUWe5fz+ZYmmHVW0erbQC8Cxv2Q6SG/eylcfiNDdLG\narf+HNxcvlJ3v7I2w79tqSbHPcJc1QKBwQD6E/zRYiuJCd0ydnJXPCzZ3dhs/Nz0\ny9QJXg7QyLuHPGEV6r2nIK/Ku3d0NHi/hWglCrg2m8ik7BKaIUjvwVI7M/E3gcZu\ngknmlWjt5QY+LLfQdVgBeqwJdqLHXtw2GAJch6LGSxIcZ5F+1MmqUbfElUJ4h/To\nno6CFGfmAc2n6+PSMWxHT6Oe/rrAFQ2B25Kl9kIrfAUeWhtLm+n0ARXo7wKr63rg\nyJBXwr5Rl3U1NJGnuagQqcS7zDdZ2Glaj1cCgcEAzOIwl5Z0I42vU+2z9e+23Tyc\nHnSyp7AaHLJeuv92T8j7sF8qV1brYQqqzUAGpIGR6OZ9Vj2niPdbtdAQpgcTav+9\nBY9Nyk6YDgsTuN+bQEWsM8VfMUFVUXQAdNFJT6VPO877Fi0PnWhqxVVzr7GuUJFM\nzTUSscsqT40Ht2v1v+qYM4EziPUtUlxUbfuc0RwtfbSpALJG+rpPjvdddQ4Xsdj0\nEIoq1r/0v+vo0Dbpdy63N0iYh9r9yHioiUdCPUgPAoHBAJhKL7260NRFQ4UFiKAD\nLzUF2lSUsGIK9nc15kPS2hCC/oSATTpHt4X4H8iOY7IOJdvY6VGoEMoOUU23U1le\nGxueiBjLWPHXOfXHqvykaebXCKFTtGJCOB4TNxG+fNAcUuPSXZfwA3l0wK/CGYU0\n+nomgzIvaT93v0UL9DGni3vlNPm9yziqEPQ0H7n1mCIqeuXCT413mw5exRyIODK1\nrogJdVEIt+3Hdc9b8tZxK5lZCBJiBy0OlZXfyR1XouDZRQKBwC1++N1gio+ukcVo\nXnL5dTjxkZVtwpJcF6BRt5l8yu/yqHlE2KkmYwRckwsa8Z6sKxN1w1VYQZC3pQTd\nnCTSI2y6N2Y5qUOIalmL+igud1IxZojkhjvwzxpUURmfs9Dc25hjYPxOq03/9t21\nGQhlw1ieu1hCNdGHVPDvV0xSy/J/DKc7RI9gKl1EpXb6zZrdz/g/GtxNuldI8gvE\nQFuS8o4KqD/X/qVLYPURVNSPrQ5LMGI1W7GnXn2a1YoOadYj3wKBwQCh+crvbhDr\njb2ud3CJfdCs5sS5SEKADiUcxiJPcypxhmu+7vhG1Nr6mT0SAYWaA36GDJkU7/Oo\nvoal+uigbOt/UugS1nQYnEzDRkTidQMm1gXVNcWRTBFTKwRP/Gd6yOp9BUHJlFCu\nM2q8HYFtmSqOele6xFOAUnHhwVx4QURJYa+S5A603Jm6ETv0+Y6xdHX/02vA+pRt\nlQqaoEO7ScdRrzjgvVxXkEY3nwLcWdM61/RZTL0+be8goDw5cWt+PaA=\n-----END RSA PRIVATE KEY-----",
@@ -429,7 +429,7 @@ func TestVerifySignatureErrors(t *testing.T) {
 				Scheme: "rsassa-pss-sha256",
 			},
 			sig: Signature{
-				KeyId: "b7d643dec0a051096ee5d87221b5d91a33daa658699d30903e1cefb90c418401",
+				KeyID: "b7d643dec0a051096ee5d87221b5d91a33daa658699d30903e1cefb90c418401",
 				Sig:   "b7d643dec0a051096ee5d87221b5d91a33daa658699d30903e1cefb90c418401",
 			},
 			expectedError: ErrInvalidSignature,
@@ -437,8 +437,8 @@ func TestVerifySignatureErrors(t *testing.T) {
 		{
 			name: "fail RSA parsing",
 			key: Key{
-				KeyId:               "b7d643dec0a051096ee5d87221b5d91a33daa658699d30903e1cefb90c418401",
-				KeyIdHashAlgorithms: []string{"sha256"},
+				KeyID:               "b7d643dec0a051096ee5d87221b5d91a33daa658699d30903e1cefb90c418401",
+				KeyIDHashAlgorithms: []string{"sha256"},
 				KeyType:             "rsa",
 				KeyVal: KeyVal{
 					Private: "-----BEGIN EC PRIVATE KEY-----\nMHQCAQEEIJ+y3Jy7kstRBzPmoOfak4t70DsLpFmlZLtppfcP14V3oAcGBSuBBAAK\noUQDQgAELToC9CwqXL8bRTG54QMn3k6dqwI0sDMTOZkriRklJ4HXQbJUWRpv2X8k\nspRECJZDoiOV1OaMMIXjY4XNeoEBmw==\n-----END EC PRIVATE KEY-----\n",
@@ -447,7 +447,7 @@ func TestVerifySignatureErrors(t *testing.T) {
 				Scheme: "rsassa-pss-sha256",
 			},
 			sig: Signature{
-				KeyId: "b7d643dec0a051096ee5d87221b5d91a33daa658699d30903e1cefb90c418401",
+				KeyID: "b7d643dec0a051096ee5d87221b5d91a33daa658699d30903e1cefb90c418401",
 				Sig:   "b7d643dec0a051096ee5d87221b5d91a33daa658699d30903e1cefb90c418401",
 			},
 			expectedError: ErrFailedPEMParsing,
@@ -455,8 +455,8 @@ func TestVerifySignatureErrors(t *testing.T) {
 		{
 			name: "ecdsa Key, but RSA KeyVal",
 			key: Key{
-				KeyId:               "b7d643dec0a051096ee5d87221b5d91a33daa658699d30903e1cefb90c418401",
-				KeyIdHashAlgorithms: []string{"sha256"},
+				KeyID:               "b7d643dec0a051096ee5d87221b5d91a33daa658699d30903e1cefb90c418401",
+				KeyIDHashAlgorithms: []string{"sha256"},
 				KeyType:             "ecdsa",
 				KeyVal: KeyVal{
 					Private: "-----BEGIN RSA PRIVATE KEY-----\nMIIG5QIBAAKCAYEAyCTik98953hKl6+B6n5l8DVIDwDnvrJfpasbJ3+Rw66YcawO\nZinRpMxPTqWBKs7sRop7jqsQNcslUoIZLrXPr3foPHF455TlrqPVfCZiFQ+O4Caf\nxWOB4mL1NddvpFXTEjmUiwFrrL7PcvQKMbYzeUHH4tH9MNzqKWbbJoekBsDpCDIx\np1NbgivGBKwjRGa281sClKgpd0Q0ebl+RTcTvpfZVDbXazQ7VqZkidt7geWq2Bid\nOXZp/cjoXyVneKx/gYiOUv8x94svQMzSEhw2LFMQ04A1KnGn1jxO35/fd6/OW32n\njyWs96RKu9UQVacYHsQfsACPWwmVqgnX/sp5ujlvSDjyfZu7c5yUQ2asYfQPLvnj\nG+u7QcBukGf8hAfVgsezzX9QPiK35BKDgBU/Vk43riJs165TJGYGVuLUhIEhHgiQ\ntwo8pUTJS5npEe5XMDuZoighNdzoWY2nfsBfp8348k6vJtDMB093/t6V9sTGYQcS\nbgKPyEQo5Pk6Wd4ZAgMBAAECggGBAIb8YZiMA2tfNSfy5jNqhoQo223LFYIHOf05\nVvofzwbkdcqM2bVL1SpJ5d9MPr7Jio/VDJpfg3JUjdqFBkj7tJRK0eYaPgoq4XIU\n64JtPM+pi5pgUnfFsi8mwO1MXO7AN7hd/3J1RdLfanjEYS/ADB1nIVI4gIR5KrE7\nvujQqO8pIsI1YEnTLa+wqEA0fSDACfo90pLCjBz1clL6qVAzYmy0a46h4k5ajv7V\nAI/96OHmLYDLsRa1Z60T2K17Q7se0zmHSjfssLQ+d+0zdU5BK8wFn1n2DvCc310T\na0ip+V+YNT0FBtmknTobnr9S688bR8vfBK0q0JsZ1YataGyYS0Rp0RYeEInjKie8\nDIzGuYNRzEjrYMlIOCCY5ybo9mbRiQEQvlSunFAAoKyr8svwU8/e2HV4lXxqDY9v\nKZzxeNYVvX2ZUP3D/uz74VvUWe5fz+ZYmmHVW0erbQC8Cxv2Q6SG/eylcfiNDdLG\narf+HNxcvlJ3v7I2w79tqSbHPcJc1QKBwQD6E/zRYiuJCd0ydnJXPCzZ3dhs/Nz0\ny9QJXg7QyLuHPGEV6r2nIK/Ku3d0NHi/hWglCrg2m8ik7BKaIUjvwVI7M/E3gcZu\ngknmlWjt5QY+LLfQdVgBeqwJdqLHXtw2GAJch6LGSxIcZ5F+1MmqUbfElUJ4h/To\nno6CFGfmAc2n6+PSMWxHT6Oe/rrAFQ2B25Kl9kIrfAUeWhtLm+n0ARXo7wKr63rg\nyJBXwr5Rl3U1NJGnuagQqcS7zDdZ2Glaj1cCgcEAzOIwl5Z0I42vU+2z9e+23Tyc\nHnSyp7AaHLJeuv92T8j7sF8qV1brYQqqzUAGpIGR6OZ9Vj2niPdbtdAQpgcTav+9\nBY9Nyk6YDgsTuN+bQEWsM8VfMUFVUXQAdNFJT6VPO877Fi0PnWhqxVVzr7GuUJFM\nzTUSscsqT40Ht2v1v+qYM4EziPUtUlxUbfuc0RwtfbSpALJG+rpPjvdddQ4Xsdj0\nEIoq1r/0v+vo0Dbpdy63N0iYh9r9yHioiUdCPUgPAoHBAJhKL7260NRFQ4UFiKAD\nLzUF2lSUsGIK9nc15kPS2hCC/oSATTpHt4X4H8iOY7IOJdvY6VGoEMoOUU23U1le\nGxueiBjLWPHXOfXHqvykaebXCKFTtGJCOB4TNxG+fNAcUuPSXZfwA3l0wK/CGYU0\n+nomgzIvaT93v0UL9DGni3vlNPm9yziqEPQ0H7n1mCIqeuXCT413mw5exRyIODK1\nrogJdVEIt+3Hdc9b8tZxK5lZCBJiBy0OlZXfyR1XouDZRQKBwC1++N1gio+ukcVo\nXnL5dTjxkZVtwpJcF6BRt5l8yu/yqHlE2KkmYwRckwsa8Z6sKxN1w1VYQZC3pQTd\nnCTSI2y6N2Y5qUOIalmL+igud1IxZojkhjvwzxpUURmfs9Dc25hjYPxOq03/9t21\nGQhlw1ieu1hCNdGHVPDvV0xSy/J/DKc7RI9gKl1EpXb6zZrdz/g/GtxNuldI8gvE\nQFuS8o4KqD/X/qVLYPURVNSPrQ5LMGI1W7GnXn2a1YoOadYj3wKBwQCh+crvbhDr\njb2ud3CJfdCs5sS5SEKADiUcxiJPcypxhmu+7vhG1Nr6mT0SAYWaA36GDJkU7/Oo\nvoal+uigbOt/UugS1nQYnEzDRkTidQMm1gXVNcWRTBFTKwRP/Gd6yOp9BUHJlFCu\nM2q8HYFtmSqOele6xFOAUnHhwVx4QURJYa+S5A603Jm6ETv0+Y6xdHX/02vA+pRt\nlQqaoEO7ScdRrzjgvVxXkEY3nwLcWdM61/RZTL0+be8goDw5cWt+PaA=\n-----END RSA PRIVATE KEY-----",
@@ -465,7 +465,7 @@ func TestVerifySignatureErrors(t *testing.T) {
 				Scheme: "ecdsa-sha2-nistp521",
 			},
 			sig: Signature{
-				KeyId: "b7d643dec0a051096ee5d87221b5d91a33daa658699d30903e1cefb90c418401",
+				KeyID: "b7d643dec0a051096ee5d87221b5d91a33daa658699d30903e1cefb90c418401",
 				Sig:   "b7d643dec0a051096ee5d87221b5d91a33daa658699d30903e1cefb90c418401",
 			},
 			expectedError: ErrKeyKeyTypeMismatch,
@@ -473,8 +473,8 @@ func TestVerifySignatureErrors(t *testing.T) {
 		{
 			name: "invalid hex string for ed25519",
 			key: Key{
-				KeyId:               "b7d643dec0a051096ee5d87221b5d91a33daa658699d30903e1cefb90c418401",
-				KeyIdHashAlgorithms: []string{"sha256"},
+				KeyID:               "b7d643dec0a051096ee5d87221b5d91a33daa658699d30903e1cefb90c418401",
+				KeyIDHashAlgorithms: []string{"sha256"},
 				KeyType:             "ed25519",
 				KeyVal: KeyVal{
 					Private: "invalid",
@@ -483,7 +483,7 @@ func TestVerifySignatureErrors(t *testing.T) {
 				Scheme: "ed25519",
 			},
 			sig: Signature{
-				KeyId: "b7d643dec0a051096ee5d87221b5d91a33daa658699d30903e1cefb90c418401",
+				KeyID: "b7d643dec0a051096ee5d87221b5d91a33daa658699d30903e1cefb90c418401",
 				Sig:   "b7d643dec0a051096ee5d87221b5d91a33daa658699d30903e1cefb90c418401",
 			},
 			expectedError: ErrInvalidHexString,
@@ -491,8 +491,8 @@ func TestVerifySignatureErrors(t *testing.T) {
 		{
 			name: "p224 ecdsa key, but wrong scheme",
 			key: Key{
-				KeyId:               "be6371bc627318218191ce0780fd3183cce6c36da02938a477d2e4dfae1804a6",
-				KeyIdHashAlgorithms: []string{"sha256"},
+				KeyID:               "be6371bc627318218191ce0780fd3183cce6c36da02938a477d2e4dfae1804a6",
+				KeyIDHashAlgorithms: []string{"sha256"},
 				KeyType:             "ecdsa",
 				KeyVal: KeyVal{
 					Private: "-----BEGIN PRIVATE KEY-----\nMHgCAQAwEAYHKoZIzj0CAQYFK4EEACEEYTBfAgEBBBwmUI9xaiYTFQU6OYl/jTnr\n+q2TfUh5LU8U4BrzoTwDOgAEu8hZFOOIyjE5FY71KsUbMOp6OB6e2T4dnFbo0Wrx\nrQFHFtW5Y3kiv6GEVF2mNDllRwJAoFpoF4M=\n-----END PRIVATE KEY-----",
@@ -505,8 +505,8 @@ func TestVerifySignatureErrors(t *testing.T) {
 		{
 			name: "p384 ecdsa key, but wrong scheme",
 			key: Key{
-				KeyId:               "be6371bc627318218191ce0780fd3183cce6c36da02938a477d2e4dfae1804a6",
-				KeyIdHashAlgorithms: []string{"sha256"},
+				KeyID:               "be6371bc627318218191ce0780fd3183cce6c36da02938a477d2e4dfae1804a6",
+				KeyIDHashAlgorithms: []string{"sha256"},
 				KeyType:             "ecdsa",
 				KeyVal: KeyVal{
 					Private: "-----BEGIN PRIVATE KEY-----\nMIG2AgEAMBAGByqGSM49AgEGBSuBBAAiBIGeMIGbAgEBBDCgpTsIXQ7HswVRgS8Z\nPdSCaGrA87YwUctguSPjvCxy9+sP1791Qx5IYy3RkAzlx8+hZANiAAQ/wpAeooDd\nCGIZBLqOV+hNcmUZMZxfF3Yi2aapT/Ly6vJQ2xedXSdaWgKw5srRcAyswPWJa8dg\nxINXXg8/S9rAs36N9XuWtzkgnDLVoWE+V6shKDB7c6Csol0WSfwsa7Y=\n-----END PRIVATE KEY-----\n",
@@ -519,8 +519,8 @@ func TestVerifySignatureErrors(t *testing.T) {
 		{
 			name: "p521 ecdsa key, but wrong scheme",
 			key: Key{
-				KeyId:               "be6371bc627318218191ce0780fd3183cce6c36da02938a477d2e4dfae1804a6",
-				KeyIdHashAlgorithms: []string{"sha256"},
+				KeyID:               "be6371bc627318218191ce0780fd3183cce6c36da02938a477d2e4dfae1804a6",
+				KeyIDHashAlgorithms: []string{"sha256"},
 				KeyType:             "ecdsa",
 				KeyVal: KeyVal{
 					Private: "-----BEGIN PRIVATE KEY-----\nMIHuAgEAMBAGByqGSM49AgEGBSuBBAAjBIHWMIHTAgEBBEIB6fQnV71xKx6kFgJv\nYTMq0ytvWi2mDlYu6aNm1761c1OSInbBxBNb0ligpM65KyaeeRce6JR9eQW6TB6R\n+5pNzvOhgYkDgYYABAFy0CeDAyV/2mY1NqxLLgqEXSxaqM3fM8gYn/ZWzrLnO+1h\nK2QAanID3JuPff1NdhehhL/U1prXdyyaItA5X4ChkQHMTsiS/3HkWRuLR8L22SGs\nB+7KqOeO5ELkqHO5tsy4kvsNrmersCGRQGY6A5V/0JFhP1u1JUvAVVhfRbdQXuu3\nrw==\n-----END PRIVATE KEY-----\n",

--- a/in_toto/model.go
+++ b/in_toto/model.go
@@ -32,29 +32,29 @@ identifier, supported hash algorithms to create the identifier, the key type
 and the supported signature scheme, and the actual key value.
 */
 type Key struct {
-	KeyId               string   `json:"keyid"`
-	KeyIdHashAlgorithms []string `json:"keyid_hash_algorithms"`
+	KeyID               string   `json:"keyid"`
+	KeyIDHashAlgorithms []string `json:"keyid_hash_algorithms"`
 	KeyType             string   `json:"keytype"`
 	KeyVal              KeyVal   `json:"keyval"`
 	Scheme              string   `json:"scheme"`
 }
 
-// This error will be thrown if a field in our Key struct is empty.
+// ErrEmptyKeyField will be thrown if a field in our Key struct is empty.
 var ErrEmptyKeyField = errors.New("empty field in key")
 
-// This error will be thrown, if a string doesn't match a hex string.
+// ErrInvalidHexString will be thrown, if a string doesn't match a hex string.
 var ErrInvalidHexString = errors.New("invalid hex string")
 
-// This error will be thrown, if the given scheme and key type are not supported together.
+// ErrSchemeKeyTypeMismatch will be thrown, if the given scheme and key type are not supported together.
 var ErrSchemeKeyTypeMismatch = errors.New("the scheme and key type are not supported together")
 
-// This error will be thrown, if the specified KeyIdHashAlgorithms is not supported.
-var ErrUnsupportedKeyIdHashAlgorithms = errors.New("the given keyID hash algorithm is not supported")
+// ErrUnsupportedKeyIDHashAlgorithms will be thrown, if the specified KeyIDHashAlgorithms is not supported.
+var ErrUnsupportedKeyIDHashAlgorithms = errors.New("the given keyID hash algorithm is not supported")
 
-// This error will be thrown, if the specified keyType does not match the key
+// ErrKeyKeyTypeMismatch will be thrown, if the specified keyType does not match the key
 var ErrKeyKeyTypeMismatch = errors.New("the given key does not match its key type")
 
-// ErrNoPublicKey gets returned, when the private key value is not empty.
+// ErrNoPublicKey gets returned when the private key value is not empty.
 var ErrNoPublicKey = errors.New("the given key is not a public key")
 
 // ErrCurveSizeSchemeMismatch gets returned, when the scheme and curve size are incompatible
@@ -224,12 +224,12 @@ func matchKeyTypeScheme(key Key) error {
 
 /*
 validateKey checks the outer key object (everything, except the KeyVal struct).
-It verifies the keyId for being a hex string and checks for empty fields.
+It verifies the keyID for being a hex string and checks for empty fields.
 On success it will return nil, on error it will return the corresponding error.
 Either: ErrEmptyKeyField or ErrInvalidHexString.
 */
 func validateKey(key Key) error {
-	err := validateHexString(key.KeyId)
+	err := validateHexString(key.KeyID)
 	if err != nil {
 		return err
 	}
@@ -248,11 +248,11 @@ func validateKey(key Key) error {
 	if err != nil {
 		return err
 	}
-	// only check for supported keyIdHashAlgorithms, if the variable has been set
-	if key.KeyIdHashAlgorithms != nil {
-		supportedKeyIdHashAlgorithms := getSupportedKeyIdHashAlgorithms()
-		if !supportedKeyIdHashAlgorithms.IsSubSet(NewSet(key.KeyIdHashAlgorithms...)) {
-			return fmt.Errorf("%w: %#v, supported are: %#v", ErrUnsupportedKeyIdHashAlgorithms, key.KeyIdHashAlgorithms, getSupportedKeyIdHashAlgorithms())
+	// only check for supported KeyIDHashAlgorithms, if the variable has been set
+	if key.KeyIDHashAlgorithms != nil {
+		supportedKeyIDHashAlgorithms := getSupportedKeyIDHashAlgorithms()
+		if !supportedKeyIDHashAlgorithms.IsSubSet(NewSet(key.KeyIDHashAlgorithms...)) {
+			return fmt.Errorf("%w: %#v, supported are: %#v", ErrUnsupportedKeyIDHashAlgorithms, key.KeyIDHashAlgorithms, getSupportedKeyIDHashAlgorithms())
 		}
 	}
 	return nil
@@ -280,7 +280,7 @@ of the Key, which was used to create the signature and the signature data.  The
 used signature scheme is found in the corresponding Key.
 */
 type Signature struct {
-	KeyId string `json:"keyid"`
+	KeyID string `json:"keyid"`
 	Sig   string `json:"sig"`
 }
 
@@ -289,7 +289,7 @@ validateSignature is a function used to check if a passed signature is valid,
 by inspecting the key ID and the signature itself.
 */
 func validateSignature(signature Signature) error {
-	if err := validateHexString(signature.KeyId); err != nil {
+	if err := validateHexString(signature.KeyID); err != nil {
 		return err
 	}
 	if err := validateHexString(signature.Sig); err != nil {
@@ -371,19 +371,24 @@ func validateLink(link Link) error {
 /*
 LinkNameFormat represents a format string used to create the filename for a
 signed Link (wrapped in a Metablock). It consists of the name of the link and
-the first 8 characters of the signing key id.  LinkNameFormatShort is for links
-that are not signed, e.g.:
-
+the first 8 characters of the signing key id. E.g.:
 	fmt.Sprintf(LinkNameFormat, "package",
 	"2f89b9272acfc8f4a0a0f094d789fdb0ba798b0fe41f2f5f417c12f0085ff498")
 	// returns "package.2f89b9272.link"
-
-	fmt.Sprintf(LinkNameFormatShort, "unsigned")
-	// returns "unsigned.link"
-
 */
 const LinkNameFormat = "%s.%.8s.link"
+
+/*
+LinkNameFormatShort is for links that are not signed, e.g.:
+	fmt.Sprintf(LinkNameFormatShort, "unsigned")
+	// returns "unsigned.link"
+*/
 const LinkNameFormatShort = "%s.link"
+
+/*
+SublayoutLinkDirFormat represents the format of the name of the directory for
+sublayout links during the verification workflow.
+*/
 const SublayoutLinkDirFormat = "%s.%.8s"
 
 /*
@@ -494,8 +499,8 @@ func validateStep(step Step) error {
 		return fmt.Errorf("invalid Type value for step '%s': should be 'step'",
 			step.SupplyChainItem.Name)
 	}
-	for _, keyId := range step.PubKeys {
-		if err := validateHexString(keyId); err != nil {
+	for _, keyID := range step.PubKeys {
+		if err := validateHexString(keyID); err != nil {
 			return err
 		}
 	}
@@ -531,14 +536,14 @@ type Layout struct {
 // We have to manually create the interface slice first, see
 // https://golang.org/doc/faq#convert_slice_of_interface
 // TODO: Is there a better way to do polymorphism for steps and inspections?
-func (l *Layout) StepsAsInterfaceSlice() []interface{} {
+func (l *Layout) stepsAsInterfaceSlice() []interface{} {
 	stepsI := make([]interface{}, len(l.Steps))
 	for i, v := range l.Steps {
 		stepsI[i] = v
 	}
 	return stepsI
 }
-func (l *Layout) InspectAsInterfaceSlice() []interface{} {
+func (l *Layout) inspectAsInterfaceSlice() []interface{} {
 	inspectionsI := make([]interface{}, len(l.Inspect))
 	for i, v := range l.Inspect {
 		inspectionsI[i] = v
@@ -560,8 +565,8 @@ func validateLayout(layout Layout) error {
 			" invalid or of incorrect format")
 	}
 
-	for keyId, key := range layout.Keys {
-		if key.KeyId != keyId {
+	for keyID, key := range layout.Keys {
+		if key.KeyID != keyID {
 			return fmt.Errorf("invalid key found")
 		}
 		err := validatePublicKey(key)
@@ -574,9 +579,10 @@ func validateLayout(layout Layout) error {
 	for _, step := range layout.Steps {
 		if namesSeen[step.Name] {
 			return fmt.Errorf("non unique step or inspection name found")
-		} else {
-			namesSeen[step.Name] = true
 		}
+
+		namesSeen[step.Name] = true
+
 		if err := validateStep(step); err != nil {
 			return err
 		}
@@ -584,9 +590,9 @@ func validateLayout(layout Layout) error {
 	for _, inspection := range layout.Inspect {
 		if namesSeen[inspection.Name] {
 			return fmt.Errorf("non unique step or inspection name found")
-		} else {
-			namesSeen[inspection.Name] = true
 		}
+
+		namesSeen[inspection.Name] = true
 	}
 	return nil
 }
@@ -613,10 +619,10 @@ type Metablock struct {
 }
 
 /*
-checkRequiredJsonFields checks that the passed map (obj) has keys for each of
+checkRequiredJSONFields checks that the passed map (obj) has keys for each of
 the json tags in the passed struct type (typ), and returns an error otherwise.
 */
-func checkRequiredJsonFields(obj map[string]interface{},
+func checkRequiredJSONFields(obj map[string]interface{},
 	typ reflect.Type) error {
 
 	// Create list of json tags, e.g. `json:"_type"`
@@ -688,7 +694,7 @@ func (mb *Metablock) Load(path string) (err error) {
 
 	if signed["_type"] == "link" {
 		var link Link
-		if err := checkRequiredJsonFields(signed, reflect.TypeOf(link)); err != nil {
+		if err := checkRequiredJSONFields(signed, reflect.TypeOf(link)); err != nil {
 			return err
 		}
 
@@ -705,7 +711,7 @@ func (mb *Metablock) Load(path string) (err error) {
 
 	} else if signed["_type"] == "layout" {
 		var layout Layout
-		if err := checkRequiredJsonFields(signed, reflect.TypeOf(layout)); err != nil {
+		if err := checkRequiredJSONFields(signed, reflect.TypeOf(layout)); err != nil {
 			return err
 		}
 
@@ -769,14 +775,14 @@ is invalid.
 func (mb *Metablock) VerifySignature(key Key) error {
 	var sig Signature
 	for _, s := range mb.Signatures {
-		if s.KeyId == key.KeyId {
+		if s.KeyID == key.KeyID {
 			sig = s
 			break
 		}
 	}
 
 	if sig == (Signature{}) {
-		return fmt.Errorf("No signature found for key '%s'", key.KeyId)
+		return fmt.Errorf("No signature found for key '%s'", key.KeyID)
 	}
 
 	dataCanonical, err := mb.GetSignableRepresentation()

--- a/in_toto/model_test.go
+++ b/in_toto/model_test.go
@@ -28,7 +28,7 @@ func TestMetablockLoad(t *testing.T) {
 	// - invalid signed type
 	// - invalid signed field for type link
 	// - invalid signed field for type layout
-	invalidJsonBytes := [][]byte{
+	invalidJSONBytes := [][]byte{
 		[]byte("{"),
 		[]byte("{}"),
 		[]byte(`{"signatures": null, "signed": {}}`),
@@ -111,9 +111,9 @@ func TestMetablockLoad(t *testing.T) {
 		"json: unknown field \"foo\"",
 	}
 
-	for i := 0; i < len(invalidJsonBytes); i++ {
+	for i := 0; i < len(invalidJSONBytes); i++ {
 		fn := fmt.Sprintf("invalid-metadata-%v.tmp", i)
-		if err := ioutil.WriteFile(fn, invalidJsonBytes[i], 0644); err != nil {
+		if err := ioutil.WriteFile(fn, invalidJSONBytes[i], 0644); err != nil {
 			fmt.Printf("Could not write file: %s", err)
 		}
 		var mb Metablock
@@ -187,7 +187,7 @@ func TestMetablockLoadDumpLoad(t *testing.T) {
 		},
 		Signatures: []Signature{
 			{
-				KeyId: "2f89b9272acfc8f4a0a0f094d789fdb0ba798b0fe41f2f5f417c12f0085ff498",
+				KeyID: "2f89b9272acfc8f4a0a0f094d789fdb0ba798b0fe41f2f5f417c12f0085ff498",
 				Sig: "66365d379d66a2e76d39a1f048847826393127572ba43bead96419499b0256" +
 					"1a08e1cb06cf91f2addd87c30a01f776a8ccc599574bc9a2bd519558351f56cff" +
 					"a61ac4f994d0d491204ff54707937e15f9abfa97c5bda1ec1ae2a2afea63f8086" +
@@ -265,10 +265,10 @@ func TestMetablockVerifySignature(t *testing.T) {
 	mbs := []Metablock{
 		{},
 		{
-			Signatures: []Signature{{KeyId: key.KeyId, Sig: "bad sig"}},
+			Signatures: []Signature{{KeyID: key.KeyID, Sig: "bad sig"}},
 		},
 		{
-			Signatures: []Signature{{KeyId: key.KeyId}},
+			Signatures: []Signature{{KeyID: key.KeyID}},
 			Signed:     TestMetablockVerifySignature,
 		},
 	}
@@ -594,7 +594,7 @@ func TestValidateLayout(t *testing.T) {
 				Type:    "layout",
 				Expires: "2020-02-27T18:03:43Z",
 				Keys: map[string]Key{
-					"deadbeef": Key{KeyId: "livebeef"},
+					"deadbeef": Key{KeyID: "livebeef"},
 				},
 			},
 			"invalid key found",
@@ -604,7 +604,7 @@ func TestValidateLayout(t *testing.T) {
 				Type:    "layout",
 				Expires: "2020-02-27T18:03:43Z",
 				Keys: map[string]Key{
-					"deadbeef": Key{KeyId: "deadbeef"},
+					"deadbeef": Key{KeyID: "deadbeef"},
 				},
 			},
 			"empty field in key: keytype",
@@ -708,7 +708,7 @@ func TestValidateHexSchema(t *testing.T) {
 
 func TestValidatePubKey(t *testing.T) {
 	testKey := Key{
-		KeyId:   "776a00e29f3559e0141b3b096f696abc6cfb0c657ab40f441132b345b08453f5",
+		KeyID:   "776a00e29f3559e0141b3b096f696abc6cfb0c657ab40f441132b345b08453f5",
 		KeyType: "rsa",
 		KeyVal: KeyVal{
 			Private: "",
@@ -733,7 +733,7 @@ func TestValidatePubKey(t *testing.T) {
 	}
 
 	testKey = Key{
-		KeyId:   "Z776a00e29f3559e0141b3b096f696abc6cfb0c657ab40f441132b345b08453f5",
+		KeyID:   "Z776a00e29f3559e0141b3b096f696abc6cfb0c657ab40f441132b345b08453f5",
 		KeyType: "rsa",
 		KeyVal: KeyVal{
 			Private: "",
@@ -758,7 +758,7 @@ func TestValidatePubKey(t *testing.T) {
 	}
 
 	testKey = Key{
-		KeyId:   "776a00e29f3559e0141b3b096f696abc6cfb0c657ab40f441132b345b08453f5",
+		KeyID:   "776a00e29f3559e0141b3b096f696abc6cfb0c657ab40f441132b345b08453f5",
 		KeyType: "rsa",
 		KeyVal: KeyVal{
 			Private: "invalid",
@@ -783,7 +783,7 @@ func TestValidatePubKey(t *testing.T) {
 	}
 
 	testKey = Key{
-		KeyId:   "776a00e29f3559e0141b3b096f696abc6cfb0c657ab40f441132b345b08453f5",
+		KeyID:   "776a00e29f3559e0141b3b096f696abc6cfb0c657ab40f441132b345b08453f5",
 		KeyType: "rsa",
 		KeyVal: KeyVal{
 			Private: "",
@@ -802,7 +802,7 @@ func TestValidateMetablock(t *testing.T) {
 	testMetablock := Metablock{
 		Signatures: []Signature{
 			{
-				KeyId: "556caebdc0877eed53d419b60eddb1e57fa773e4e31d70698b58" +
+				KeyID: "556caebdc0877eed53d419b60eddb1e57fa773e4e31d70698b58" +
 					"8f3e9cc48b35",
 				Sig: "02813858670c66647c17802d84f06453589f41850013a544609e9d" +
 					"33ba21fa19280e8371701f8274fb0c56bd95ff4f34c418456b002af" +
@@ -837,7 +837,7 @@ func TestValidateMetablock(t *testing.T) {
 	testMetablock = Metablock{
 		Signatures: []Signature{
 			{
-				KeyId: "556caebdc0877eed53d419b60eddb1e57fa773e4e31d70698b58" +
+				KeyID: "556caebdc0877eed53d419b60eddb1e57fa773e4e31d70698b58" +
 					"8f3e9cc48b35",
 				Sig: "02813858670c66647c17802d84f06453589f41850013a544609e9d" +
 					"33ba21fa19280e8371701f8274fb0c56bd95ff4f34c418456b002af" +
@@ -892,7 +892,7 @@ func TestValidateMetablock(t *testing.T) {
 	testMetablock = Metablock{
 		Signatures: []Signature{
 			{
-				KeyId: "556caebdc0877eed53d419b60eddb1e57fa773e4e31d70698b58" +
+				KeyID: "556caebdc0877eed53d419b60eddb1e57fa773e4e31d70698b58" +
 					"8f3e9cc48b35",
 				Sig: "02813858670c66647c17802d84f06453589f41850013a544609e9d" +
 					"33ba21fa19280e8371701f8274fb0c56bd95ff4f34c418456b002af" +
@@ -928,7 +928,7 @@ func TestValidateMetablock(t *testing.T) {
 	testMetablock = Metablock{
 		Signatures: []Signature{
 			{
-				KeyId: "556caebdc0877eed53d419b60eddb1e57fa773e4e31d70698b58" +
+				KeyID: "556caebdc0877eed53d419b60eddb1e57fa773e4e31d70698b58" +
 					"8f3e9cc48b35",
 				Sig: "02813858670c66647c17802d84f06453589f41850013a544609e9d" +
 					"33ba21fa19280e8371701f8274fb0c56bd95ff4f34c418456b002af" +
@@ -984,7 +984,7 @@ func TestValidateMetablock(t *testing.T) {
 	testMetablock = Metablock{
 		Signatures: []Signature{
 			{
-				KeyId: "Z556caebdc0877eed53d419b60eddb1e57fa773e4e31d70698b5" +
+				KeyID: "Z556caebdc0877eed53d419b60eddb1e57fa773e4e31d70698b5" +
 					"8f3e9cc48b35",
 				Sig: "02813858670c66647c17802d84f06453589f41850013a544609e9d" +
 					"33ba21fa19280e8371701f8274fb0c56bd95ff4f34c418456b002af" +
@@ -1020,7 +1020,7 @@ func TestValidateMetablock(t *testing.T) {
 	testMetablock = Metablock{
 		Signatures: []Signature{
 			{
-				KeyId: "556caebdc0877eed53d419b60eddb1e57fa773e4e31d70698b58" +
+				KeyID: "556caebdc0877eed53d419b60eddb1e57fa773e4e31d70698b58" +
 					"8f3e9cc48b35",
 				Sig: "02813858670c66647c17802d84f06453589f41850013a544609e9z" +
 					"33ba21fa19280e8371701f8274fb0c56bd95ff4f34c418456b002af" +
@@ -1102,8 +1102,8 @@ func TestMetablockSignWithRSA(t *testing.T) {
 		t.Errorf("Cannot parse template file: %s", err)
 	}
 	invalidKey := Key{
-		KeyId:               "test",
-		KeyIdHashAlgorithms: nil,
+		KeyID:               "test",
+		KeyIDHashAlgorithms: nil,
 		KeyType:             "rsa",
 		KeyVal:              KeyVal{},
 		Scheme:              "rsassa-pss-sha256",
@@ -1120,8 +1120,8 @@ func TestMetablockSignWithEd25519(t *testing.T) {
 		t.Errorf("Cannot parse template file: %s", err)
 	}
 	invalidKey := Key{
-		KeyId:               "invalid",
-		KeyIdHashAlgorithms: nil,
+		KeyID:               "invalid",
+		KeyIDHashAlgorithms: nil,
 		KeyType:             "ed25519",
 		KeyVal: KeyVal{
 			Private: "BAD",
@@ -1141,8 +1141,8 @@ func TestMetaBlockSignWithEcdsa(t *testing.T) {
 		t.Errorf("Cannot parse template file: %s", err)
 	}
 	invalidKey := Key{
-		KeyId:               "invalid",
-		KeyIdHashAlgorithms: nil,
+		KeyID:               "invalid",
+		KeyIDHashAlgorithms: nil,
 		KeyType:             "ecdsa",
 		KeyVal: KeyVal{
 			Private: "BAD",
@@ -1162,15 +1162,15 @@ func TestValidateKeyErrors(t *testing.T) {
 		err  error
 	}{
 		{"empty key", Key{
-			KeyId:               "",
-			KeyIdHashAlgorithms: nil,
+			KeyID:               "",
+			KeyIDHashAlgorithms: nil,
 			KeyType:             "",
 			KeyVal:              KeyVal{},
 			Scheme:              "",
 		}, ErrInvalidHexString},
 		{"keytype missing", Key{
-			KeyId:               "bad",
-			KeyIdHashAlgorithms: []string{"sha256"},
+			KeyID:               "bad",
+			KeyIDHashAlgorithms: []string{"sha256"},
 			KeyType:             "",
 			KeyVal: KeyVal{
 				Private: "",
@@ -1179,8 +1179,8 @@ func TestValidateKeyErrors(t *testing.T) {
 			Scheme: "rsassa-psa-sha256",
 		}, ErrEmptyKeyField},
 		{"key scheme missing", Key{
-			KeyId:               "bad",
-			KeyIdHashAlgorithms: []string{"sha256"},
+			KeyID:               "bad",
+			KeyIDHashAlgorithms: []string{"sha256"},
 			KeyType:             "ed25519",
 			KeyVal: KeyVal{
 				Private: "bad",
@@ -1191,8 +1191,8 @@ func TestValidateKeyErrors(t *testing.T) {
 		{
 			name: "invalid key type",
 			key: Key{
-				KeyId:               "bad",
-				KeyIdHashAlgorithms: []string{"sha256"},
+				KeyID:               "bad",
+				KeyIDHashAlgorithms: []string{"sha256"},
 				KeyType:             "invalid",
 				KeyVal: KeyVal{
 					Private: "invalid",
@@ -1205,8 +1205,8 @@ func TestValidateKeyErrors(t *testing.T) {
 		{
 			name: "keytype scheme mismatch",
 			key: Key{
-				KeyId:               "be6371bc627318218191ce0780fd3183cce6c36da02938a477d2e4dfae1804a6",
-				KeyIdHashAlgorithms: []string{"sha256"},
+				KeyID:               "be6371bc627318218191ce0780fd3183cce6c36da02938a477d2e4dfae1804a6",
+				KeyIDHashAlgorithms: []string{"sha256"},
 				KeyType:             "ed25519",
 				KeyVal: KeyVal{
 					Private: "29ad59693fe94c9d623afbb66554b4f6bb248c47761689ada4875ebda94840ae393e671b200f964c49083d34a867f5d989ec1c69df7b66758fe471c8591b139c",
@@ -1217,10 +1217,10 @@ func TestValidateKeyErrors(t *testing.T) {
 			err: ErrSchemeKeyTypeMismatch,
 		},
 		{
-			name: "unsupported KeyIdHashAlgorithms",
+			name: "unsupported KeyIDHashAlgorithms",
 			key: Key{
-				KeyId:               "be6371bc627318218191ce0780fd3183cce6c36da02938a477d2e4dfae1804a6",
-				KeyIdHashAlgorithms: []string{"sha128"},
+				KeyID:               "be6371bc627318218191ce0780fd3183cce6c36da02938a477d2e4dfae1804a6",
+				KeyIDHashAlgorithms: []string{"sha128"},
 				KeyType:             "ed25519",
 				KeyVal: KeyVal{
 					Private: "29ad59693fe94c9d623afbb66554b4f6bb248c47761689ada4875ebda94840ae393e671b200f964c49083d34a867f5d989ec1c69df7b66758fe471c8591b139c",
@@ -1228,7 +1228,7 @@ func TestValidateKeyErrors(t *testing.T) {
 				},
 				Scheme: "ed25519",
 			},
-			err: ErrUnsupportedKeyIdHashAlgorithms,
+			err: ErrUnsupportedKeyIDHashAlgorithms,
 		},
 	}
 
@@ -1249,8 +1249,8 @@ func TestValidateKeyVal(t *testing.T) {
 		{
 			name: "invalid rsa private key",
 			key: Key{
-				KeyId:               "bad",
-				KeyIdHashAlgorithms: []string{"sha256"},
+				KeyID:               "bad",
+				KeyIDHashAlgorithms: []string{"sha256"},
 				KeyType:             "rsa",
 				KeyVal: KeyVal{
 					Private: "invalid",
@@ -1263,8 +1263,8 @@ func TestValidateKeyVal(t *testing.T) {
 		{
 			name: "invalid rsa pub key",
 			key: Key{
-				KeyId:               "bad",
-				KeyIdHashAlgorithms: []string{"sha256"},
+				KeyID:               "bad",
+				KeyIDHashAlgorithms: []string{"sha256"},
 				KeyType:             "rsa",
 				KeyVal: KeyVal{
 					Private: "",
@@ -1277,8 +1277,8 @@ func TestValidateKeyVal(t *testing.T) {
 		{
 			name: "invalid ed25519 public key",
 			key: Key{
-				KeyId:               "bad",
-				KeyIdHashAlgorithms: []string{"sha256"},
+				KeyID:               "bad",
+				KeyIDHashAlgorithms: []string{"sha256"},
 				KeyType:             "ed25519",
 				KeyVal: KeyVal{
 					Private: "invalid",
@@ -1291,8 +1291,8 @@ func TestValidateKeyVal(t *testing.T) {
 		{
 			name: "invalid ed25519 private key",
 			key: Key{
-				KeyId:               "bad",
-				KeyIdHashAlgorithms: []string{"sha256"},
+				KeyID:               "bad",
+				KeyIDHashAlgorithms: []string{"sha256"},
 				KeyType:             "ed25519",
 				KeyVal: KeyVal{
 					Private: "invalid",
@@ -1305,8 +1305,8 @@ func TestValidateKeyVal(t *testing.T) {
 		{
 			name: "valid rsa public, but bad private key",
 			key: Key{
-				KeyId:               "b7d643dec0a051096ee5d87221b5d91a33daa658699d30903e1cefb90c418401",
-				KeyIdHashAlgorithms: []string{"sha256"},
+				KeyID:               "b7d643dec0a051096ee5d87221b5d91a33daa658699d30903e1cefb90c418401",
+				KeyIDHashAlgorithms: []string{"sha256"},
 				KeyType:             "rsa",
 				KeyVal: KeyVal{
 					Private: "-----BEGIN PRIVATE KEY-----\nMIHuAgEAMBAGByqGSM49AgEGBSuBBAAjBIHWMIHTAgEBBEIB6fQnV71xKx6kFgJv\nYTMq0ytvWi2mDlYu6aNm1761c1OSInbBxBNb0ligpM65KyaeeRce6JR9eQW6TB6R\n+5pNzvOhgYkDgYYABAFy0CeDAyV/2mY1NqxLLgqEXSxaqM3fM8gYn/ZWzrLnO+1h\nK2QAanID3JuPff1NdhehhL/U1prXdyyaItA5X4ChkQHMTsiS/3HkWRuLR8L22SGs\nB+7KqOeO5ELkqHO5tsy4kvsNrmersCGRQGY6A5V/0JFhP1u1JUvAVVhfRbdQXuu3\nrw==\n-----END PRIVATE KEY-----\n",
@@ -1319,8 +1319,8 @@ func TestValidateKeyVal(t *testing.T) {
 		{
 			name: "valid ecdsa public key, but invalid ecdsa private key",
 			key: Key{
-				KeyId:               "b7d643dec0a051096ee5d87221b5d91a33daa658699d30903e1cefb90c418401",
-				KeyIdHashAlgorithms: []string{"sha256"},
+				KeyID:               "b7d643dec0a051096ee5d87221b5d91a33daa658699d30903e1cefb90c418401",
+				KeyIDHashAlgorithms: []string{"sha256"},
 				KeyType:             "ecdsa",
 				KeyVal: KeyVal{
 					Private: "-----BEGIN RSA PRIVATE KEY-----\nMIIG5QIBAAKCAYEAyCTik98953hKl6+B6n5l8DVIDwDnvrJfpasbJ3+Rw66YcawO\nZinRpMxPTqWBKs7sRop7jqsQNcslUoIZLrXPr3foPHF455TlrqPVfCZiFQ+O4Caf\nxWOB4mL1NddvpFXTEjmUiwFrrL7PcvQKMbYzeUHH4tH9MNzqKWbbJoekBsDpCDIx\np1NbgivGBKwjRGa281sClKgpd0Q0ebl+RTcTvpfZVDbXazQ7VqZkidt7geWq2Bid\nOXZp/cjoXyVneKx/gYiOUv8x94svQMzSEhw2LFMQ04A1KnGn1jxO35/fd6/OW32n\njyWs96RKu9UQVacYHsQfsACPWwmVqgnX/sp5ujlvSDjyfZu7c5yUQ2asYfQPLvnj\nG+u7QcBukGf8hAfVgsezzX9QPiK35BKDgBU/Vk43riJs165TJGYGVuLUhIEhHgiQ\ntwo8pUTJS5npEe5XMDuZoighNdzoWY2nfsBfp8348k6vJtDMB093/t6V9sTGYQcS\nbgKPyEQo5Pk6Wd4ZAgMBAAECggGBAIb8YZiMA2tfNSfy5jNqhoQo223LFYIHOf05\nVvofzwbkdcqM2bVL1SpJ5d9MPr7Jio/VDJpfg3JUjdqFBkj7tJRK0eYaPgoq4XIU\n64JtPM+pi5pgUnfFsi8mwO1MXO7AN7hd/3J1RdLfanjEYS/ADB1nIVI4gIR5KrE7\nvujQqO8pIsI1YEnTLa+wqEA0fSDACfo90pLCjBz1clL6qVAzYmy0a46h4k5ajv7V\nAI/96OHmLYDLsRa1Z60T2K17Q7se0zmHSjfssLQ+d+0zdU5BK8wFn1n2DvCc310T\na0ip+V+YNT0FBtmknTobnr9S688bR8vfBK0q0JsZ1YataGyYS0Rp0RYeEInjKie8\nDIzGuYNRzEjrYMlIOCCY5ybo9mbRiQEQvlSunFAAoKyr8svwU8/e2HV4lXxqDY9v\nKZzxeNYVvX2ZUP3D/uz74VvUWe5fz+ZYmmHVW0erbQC8Cxv2Q6SG/eylcfiNDdLG\narf+HNxcvlJ3v7I2w79tqSbHPcJc1QKBwQD6E/zRYiuJCd0ydnJXPCzZ3dhs/Nz0\ny9QJXg7QyLuHPGEV6r2nIK/Ku3d0NHi/hWglCrg2m8ik7BKaIUjvwVI7M/E3gcZu\ngknmlWjt5QY+LLfQdVgBeqwJdqLHXtw2GAJch6LGSxIcZ5F+1MmqUbfElUJ4h/To\nno6CFGfmAc2n6+PSMWxHT6Oe/rrAFQ2B25Kl9kIrfAUeWhtLm+n0ARXo7wKr63rg\nyJBXwr5Rl3U1NJGnuagQqcS7zDdZ2Glaj1cCgcEAzOIwl5Z0I42vU+2z9e+23Tyc\nHnSyp7AaHLJeuv92T8j7sF8qV1brYQqqzUAGpIGR6OZ9Vj2niPdbtdAQpgcTav+9\nBY9Nyk6YDgsTuN+bQEWsM8VfMUFVUXQAdNFJT6VPO877Fi0PnWhqxVVzr7GuUJFM\nzTUSscsqT40Ht2v1v+qYM4EziPUtUlxUbfuc0RwtfbSpALJG+rpPjvdddQ4Xsdj0\nEIoq1r/0v+vo0Dbpdy63N0iYh9r9yHioiUdCPUgPAoHBAJhKL7260NRFQ4UFiKAD\nLzUF2lSUsGIK9nc15kPS2hCC/oSATTpHt4X4H8iOY7IOJdvY6VGoEMoOUU23U1le\nGxueiBjLWPHXOfXHqvykaebXCKFTtGJCOB4TNxG+fNAcUuPSXZfwA3l0wK/CGYU0\n+nomgzIvaT93v0UL9DGni3vlNPm9yziqEPQ0H7n1mCIqeuXCT413mw5exRyIODK1\nrogJdVEIt+3Hdc9b8tZxK5lZCBJiBy0OlZXfyR1XouDZRQKBwC1++N1gio+ukcVo\nXnL5dTjxkZVtwpJcF6BRt5l8yu/yqHlE2KkmYwRckwsa8Z6sKxN1w1VYQZC3pQTd\nnCTSI2y6N2Y5qUOIalmL+igud1IxZojkhjvwzxpUURmfs9Dc25hjYPxOq03/9t21\nGQhlw1ieu1hCNdGHVPDvV0xSy/J/DKc7RI9gKl1EpXb6zZrdz/g/GtxNuldI8gvE\nQFuS8o4KqD/X/qVLYPURVNSPrQ5LMGI1W7GnXn2a1YoOadYj3wKBwQCh+crvbhDr\njb2ud3CJfdCs5sS5SEKADiUcxiJPcypxhmu+7vhG1Nr6mT0SAYWaA36GDJkU7/Oo\nvoal+uigbOt/UugS1nQYnEzDRkTidQMm1gXVNcWRTBFTKwRP/Gd6yOp9BUHJlFCu\nM2q8HYFtmSqOele6xFOAUnHhwVx4QURJYa+S5A603Jm6ETv0+Y6xdHX/02vA+pRt\nlQqaoEO7ScdRrzjgvVxXkEY3nwLcWdM61/RZTL0+be8goDw5cWt+PaA=\n-----END RSA PRIVATE KEY-----",
@@ -1333,8 +1333,8 @@ func TestValidateKeyVal(t *testing.T) {
 		{
 			name: "rsa key, but with ed25519 private key",
 			key: Key{
-				KeyId:               "b7d643dec0a051096ee5d87221b5d91a33daa658699d30903e1cefb90c418401",
-				KeyIdHashAlgorithms: []string{"sha256"},
+				KeyID:               "b7d643dec0a051096ee5d87221b5d91a33daa658699d30903e1cefb90c418401",
+				KeyIDHashAlgorithms: []string{"sha256"},
 				KeyType:             "rsa",
 				KeyVal: KeyVal{
 					Private: "-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VwBCIEICmtWWk/6UydYjr7tmVUtPa7JIxHdhaJraSHXr2pSECu\n-----END PRIVATE KEY-----\n",
@@ -1347,8 +1347,8 @@ func TestValidateKeyVal(t *testing.T) {
 		{
 			name: "unsupported key type",
 			key: Key{
-				KeyId:               "",
-				KeyIdHashAlgorithms: nil,
+				KeyID:               "",
+				KeyIDHashAlgorithms: nil,
 				KeyType:             "invalid",
 				KeyVal:              KeyVal{},
 				Scheme:              "",
@@ -1358,8 +1358,8 @@ func TestValidateKeyVal(t *testing.T) {
 		{
 			name: "rsa key type, but ed25519 key",
 			key: Key{
-				KeyId:               "b7d643dec0a051096ee5d87221b5d91a33daa658699d30903e1cefb90c418401",
-				KeyIdHashAlgorithms: []string{"sha256"},
+				KeyID:               "b7d643dec0a051096ee5d87221b5d91a33daa658699d30903e1cefb90c418401",
+				KeyIDHashAlgorithms: []string{"sha256"},
 				KeyType:             "rsa",
 				KeyVal: KeyVal{
 					Private: "-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VwBCIEICmtWWk/6UydYjr7tmVUtPa7JIxHdhaJraSHXr2pSECu\n-----END PRIVATE KEY-----\n",
@@ -1372,8 +1372,8 @@ func TestValidateKeyVal(t *testing.T) {
 		{
 			name: "rsa key, but not ecdsa key type",
 			key: Key{
-				KeyId:               "b7d643dec0a051096ee5d87221b5d91a33daa658699d30903e1cefb90c418401",
-				KeyIdHashAlgorithms: []string{"sha256"},
+				KeyID:               "b7d643dec0a051096ee5d87221b5d91a33daa658699d30903e1cefb90c418401",
+				KeyIDHashAlgorithms: []string{"sha256"},
 				KeyType:             "ecdsa",
 				KeyVal: KeyVal{
 					Private: "",
@@ -1386,8 +1386,8 @@ func TestValidateKeyVal(t *testing.T) {
 		{
 			name: "ecdsa key, but rsa key type",
 			key: Key{
-				KeyId:               "b7d643dec0a051096ee5d87221b5d91a33daa658699d30903e1cefb90c418401",
-				KeyIdHashAlgorithms: []string{"sha256"},
+				KeyID:               "b7d643dec0a051096ee5d87221b5d91a33daa658699d30903e1cefb90c418401",
+				KeyIDHashAlgorithms: []string{"sha256"},
 				KeyType:             "rsa",
 				KeyVal: KeyVal{
 					Private: "-----BEGIN PRIVATE KEY-----\nMIHuAgEAMBAGByqGSM49AgEGBSuBBAAjBIHWMIHTAgEBBEIB6fQnV71xKx6kFgJv\nYTMq0ytvWi2mDlYu6aNm1761c1OSInbBxBNb0ligpM65KyaeeRce6JR9eQW6TB6R\n+5pNzvOhgYkDgYYABAFy0CeDAyV/2mY1NqxLLgqEXSxaqM3fM8gYn/ZWzrLnO+1h\nK2QAanID3JuPff1NdhehhL/U1prXdyyaItA5X4ChkQHMTsiS/3HkWRuLR8L22SGs\nB+7KqOeO5ELkqHO5tsy4kvsNrmersCGRQGY6A5V/0JFhP1u1JUvAVVhfRbdQXuu3\nrw==\n-----END PRIVATE KEY-----\n",
@@ -1400,8 +1400,8 @@ func TestValidateKeyVal(t *testing.T) {
 		{
 			name: "ecdsa key, but rsa key type",
 			key: Key{
-				KeyId:               "b7d643dec0a051096ee5d87221b5d91a33daa658699d30903e1cefb90c418401",
-				KeyIdHashAlgorithms: []string{"sha256"},
+				KeyID:               "b7d643dec0a051096ee5d87221b5d91a33daa658699d30903e1cefb90c418401",
+				KeyIDHashAlgorithms: []string{"sha256"},
 				KeyType:             "ecdsa",
 				KeyVal: KeyVal{
 					Private: "-----BEGIN PRIVATE KEY-----\nMIHuAgEAMBAGByqGSM49AgEGBSuBBAAjBIHWMIHTAgEBBEIB6fQnV71xKx6kFgJv\nYTMq0ytvWi2mDlYu6aNm1761c1OSInbBxBNb0ligpM65KyaeeRce6JR9eQW6TB6R\n+5pNzvOhgYkDgYYABAFy0CeDAyV/2mY1NqxLLgqEXSxaqM3fM8gYn/ZWzrLnO+1h\nK2QAanID3JuPff1NdhehhL/U1prXdyyaItA5X4ChkQHMTsiS/3HkWRuLR8L22SGs\nB+7KqOeO5ELkqHO5tsy4kvsNrmersCGRQGY6A5V/0JFhP1u1JUvAVVhfRbdQXuu3\nrw==\n-----END PRIVATE KEY-----\n",
@@ -1428,8 +1428,8 @@ func TestMatchKeyTypeScheme(t *testing.T) {
 	}{
 		{name: "test for unsupported key type",
 			key: Key{
-				KeyId:               "",
-				KeyIdHashAlgorithms: nil,
+				KeyID:               "",
+				KeyIDHashAlgorithms: nil,
 				KeyType:             "invalid",
 				KeyVal:              KeyVal{},
 				Scheme:              "",
@@ -1439,8 +1439,8 @@ func TestMatchKeyTypeScheme(t *testing.T) {
 		{
 			name: "test for scheme key type mismatch",
 			key: Key{
-				KeyId:               "",
-				KeyIdHashAlgorithms: nil,
+				KeyID:               "",
+				KeyIDHashAlgorithms: nil,
 				KeyType:             "rsa",
 				KeyVal:              KeyVal{},
 				Scheme:              "ed25519",
@@ -1464,8 +1464,8 @@ func TestValidatePublicKey(t *testing.T) {
 		{
 			name: "test with valid key",
 			key: Key{
-				KeyId:               "be6371bc627318218191ce0780fd3183cce6c36da02938a477d2e4dfae1804a6",
-				KeyIdHashAlgorithms: []string{"sha512"},
+				KeyID:               "be6371bc627318218191ce0780fd3183cce6c36da02938a477d2e4dfae1804a6",
+				KeyIDHashAlgorithms: []string{"sha512"},
 				KeyType:             "ed25519",
 				KeyVal: KeyVal{
 					Private: "",
@@ -1490,8 +1490,8 @@ func TestValidatePublicKey(t *testing.T) {
 		{
 			name: "test with valid key",
 			key: Key{
-				KeyId:               "be6371bc627318218191ce0780fd3183cce6c36da02938a477d2e4dfae1804a6",
-				KeyIdHashAlgorithms: []string{"sha512"},
+				KeyID:               "be6371bc627318218191ce0780fd3183cce6c36da02938a477d2e4dfae1804a6",
+				KeyIDHashAlgorithms: []string{"sha512"},
 				KeyType:             "ed25519",
 				KeyVal: KeyVal{
 					Private: "-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VwBCIEICmtWWk/6UydYjr7tmVUtPa7JIxHdhaJraSHXr2pSECu\n-----END PRIVATE KEY-----\n",

--- a/in_toto/runlib.go
+++ b/in_toto/runlib.go
@@ -186,10 +186,10 @@ func recordArtifacts(paths []string, hashAlgorithms []string, gitignorePatterns 
 }
 
 /*
-WaitErrToExitCode converts an error returned by Cmd.wait() to an exit code.  It
+waitErrToExitCode converts an error returned by Cmd.wait() to an exit code.  It
 returns -1 if no exit code can be inferred.
 */
-func WaitErrToExitCode(err error) int {
+func waitErrToExitCode(err error) int {
 	// If there's no exit code, we return -1
 	retVal := -1
 
@@ -248,7 +248,7 @@ func RunCommand(cmdArgs []string) (map[string]interface{}, error) {
 	stdout, _ := ioutil.ReadAll(stdoutPipe)
 	stderr, _ := ioutil.ReadAll(stderrPipe)
 
-	retVal := WaitErrToExitCode(cmd.Wait())
+	retVal := waitErrToExitCode(cmd.Wait())
 
 	return map[string]interface{}{
 		"return-value": float64(retVal),

--- a/in_toto/runlib_test.go
+++ b/in_toto/runlib_test.go
@@ -305,7 +305,7 @@ func TestRecordArtifacts(t *testing.T) {
 	}
 }
 
-func TestWaitErrToExitCode(t *testing.T) {
+func TestwaitErrToExitCode(t *testing.T) {
 	// TODO: Find way to test/mock ExitError
 	// Test exit code from error assessment
 	parameters := []error{
@@ -320,9 +320,9 @@ func TestWaitErrToExitCode(t *testing.T) {
 	}
 
 	for i := 0; i < len(parameters); i++ {
-		result := WaitErrToExitCode(parameters[i])
+		result := waitErrToExitCode(parameters[i])
 		if result != expected[i] {
-			t.Errorf("WaitErrToExitCode returned %d, expected %d",
+			t.Errorf("waitErrToExitCode returned %d, expected %d",
 				result, expected[i])
 		}
 	}
@@ -396,7 +396,7 @@ func TestInTotoRun(t *testing.T) {
 				Environment: map[string]interface{}{},
 			},
 			Signatures: []Signature{{
-				KeyId: "be6371bc627318218191ce0780fd3183cce6c36da02938a477d2e4dfae1804a6",
+				KeyID: "be6371bc627318218191ce0780fd3183cce6c36da02938a477d2e4dfae1804a6",
 				Sig:   "aef29094ba7378811897e5914842e65353a834d4f73cac0dcb2148b88a436e3ddc7a6644a6695d3a20693726130f0d8ace916f6482b4a74e29cc77fd7571d401",
 			}},
 		},
@@ -439,8 +439,8 @@ func TestInTotoRun(t *testing.T) {
 		{[]string{""}, []string{"/invalid-path/"}, []string{"sh", "-c", "printf test"}, Key{}, []string{"sha256"}},
 		{[]string{}, []string{}, []string{"command-does-not-exist"}, Key{}, []string{"sha256"}},
 		{[]string{"demo.layout"}, []string{"foo.tar.gz"}, []string{"sh", "-c", "printf out; printf err >&2"}, Key{
-			KeyId:               "this-is-invalid",
-			KeyIdHashAlgorithms: nil,
+			KeyID:               "this-is-invalid",
+			KeyIDHashAlgorithms: nil,
 			KeyType:             "",
 			KeyVal:              KeyVal{},
 			Scheme:              "",

--- a/in_toto/util.go
+++ b/in_toto/util.go
@@ -138,7 +138,7 @@ func (s Set) IsSubSet(subset Set) bool {
 	if len(subset) > len(s) {
 		return false
 	}
-	for key, _ := range subset {
+	for key := range subset {
 		if s.Has(key) {
 			continue
 		} else {

--- a/in_toto/verifylib.go
+++ b/in_toto/verifylib.go
@@ -519,8 +519,8 @@ func LoadLinksForLayout(layout Layout, linkDir string) (
 	for _, step := range layout.Steps {
 		linksPerStep := make(map[string]Metablock)
 
-		for _, authorizedKeyId := range step.PubKeys {
-			linkName := fmt.Sprintf(LinkNameFormat, step.Name, authorizedKeyId)
+		for _, authorizedKeyID := range step.PubKeys {
+			linkName := fmt.Sprintf(LinkNameFormat, step.Name, authorizedKeyID)
 			linkPath := osPath.Join(linkDir, linkName)
 
 			var linkMb Metablock
@@ -528,7 +528,7 @@ func LoadLinksForLayout(layout Layout, linkDir string) (
 				continue
 			}
 
-			linksPerStep[authorizedKeyId] = linkMb
+			linksPerStep[authorizedKeyID] = linkMb
 		}
 
 		if len(linksPerStep) < step.Threshold {
@@ -553,7 +553,7 @@ func VerifyLayoutExpiration(layout Layout) error {
 	}
 	// Uses timezone of expires, i.e. UTC
 	if time.Until(expires) < 0 {
-		return fmt.Errorf("Layout has expired on '%s'.", expires)
+		return fmt.Errorf("layout has expired on '%s'", expires)
 	}
 	return nil
 }
@@ -568,7 +568,7 @@ passed keys, or a matching signature is invalid, an error is returned.
 func VerifyLayoutSignatures(layoutMb Metablock,
 	layoutKeys map[string]Key) error {
 	if len(layoutKeys) < 1 {
-		return fmt.Errorf("Layout verification requires at least one key.")
+		return fmt.Errorf("layout verification requires at least one key")
 	}
 
 	for _, key := range layoutKeys {
@@ -622,13 +622,13 @@ func VerifySublayouts(layout Layout,
 	stepsMetadataVerified map[string]map[string]Metablock,
 	superLayoutLinkPath string) (map[string]map[string]Metablock, error) {
 	for stepName, linkData := range stepsMetadataVerified {
-		for keyId, metadata := range linkData {
+		for keyID, metadata := range linkData {
 			if _, ok := metadata.Signed.(Layout); ok {
 				layoutKeys := make(map[string]Key)
-				layoutKeys[keyId] = layout.Keys[keyId]
+				layoutKeys[keyID] = layout.Keys[keyID]
 
 				sublayoutLinkDir := fmt.Sprintf(SublayoutLinkDirFormat,
-					stepName, keyId)
+					stepName, keyID)
 				sublayoutLinkPath := filepath.Join(superLayoutLinkPath,
 					sublayoutLinkDir)
 				summaryLink, err := InTotoVerify(metadata, layoutKeys,
@@ -636,7 +636,7 @@ func VerifySublayouts(layout Layout,
 				if err != nil {
 					return nil, err
 				}
-				linkData[keyId] = summaryLink
+				linkData[keyID] = summaryLink
 			}
 
 		}
@@ -808,7 +808,7 @@ func InTotoVerify(layoutMb Metablock, layoutKeys map[string]Key,
 	}
 
 	// Verify artifact rules
-	if err = VerifyArtifacts(layout.StepsAsInterfaceSlice(),
+	if err = VerifyArtifacts(layout.stepsAsInterfaceSlice(),
 		stepsMetadataReduced); err != nil {
 		return summaryLink, err
 	}
@@ -824,7 +824,7 @@ func InTotoVerify(layoutMb Metablock, layoutKeys map[string]Key,
 		inspectionMetadata[k] = v
 	}
 
-	if err = VerifyArtifacts(layout.InspectAsInterfaceSlice(),
+	if err = VerifyArtifacts(layout.inspectAsInterfaceSlice(),
 		inspectionMetadata); err != nil {
 		return summaryLink, err
 	}

--- a/in_toto/verifylib_test.go
+++ b/in_toto/verifylib_test.go
@@ -27,7 +27,7 @@ func TestInTotoVerifyPass(t *testing.T) {
 	}
 
 	var layouKeys = map[string]Key{
-		pubKey.KeyId: pubKey,
+		pubKey.KeyID: pubKey,
 	}
 
 	// No error should occur
@@ -101,7 +101,7 @@ func TestVerifySublayouts(t *testing.T) {
 		t.Errorf("Unable to load Alice's public key")
 	}
 	sublayoutDirectory := fmt.Sprintf(SublayoutLinkDirFormat, sublayoutName,
-		aliceKey.KeyId)
+		aliceKey.KeyID)
 	defer func(sublayoutDirectory string) {
 		if err := os.RemoveAll(sublayoutDirectory); err != nil {
 			t.Errorf("Unable to remove directory %s: %s", sublayoutDirectory, err)
@@ -546,9 +546,9 @@ func TestVerifyStepCommandAlignment(t *testing.T) {
 }
 
 func TestVerifyLinkSignatureThesholds(t *testing.T) {
-	keyId1 := "2f89b9272acfc8f4a0a0f094d789fdb0ba798b0fe41f2f5f417c12f0085ff498"
-	keyId2 := "776a00e29f3559e0141b3b096f696abc6cfb0c657ab40f441132b345b08453f5"
-	keyId3 := "abcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabca"
+	keyID1 := "2f89b9272acfc8f4a0a0f094d789fdb0ba798b0fe41f2f5f417c12f0085ff498"
+	keyID2 := "776a00e29f3559e0141b3b096f696abc6cfb0c657ab40f441132b345b08453f5"
+	keyID3 := "abcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabca"
 
 	var mb Metablock
 	if err := mb.Load("demo.layout"); err != nil {
@@ -559,7 +559,7 @@ func TestVerifyLinkSignatureThesholds(t *testing.T) {
 	layout.Steps = []Step{{SupplyChainItem: SupplyChainItem{
 		Name: "foo"},
 		Threshold: 2,
-		PubKeys:   []string{keyId1, keyId2, keyId3}}}
+		PubKeys:   []string{keyID1, keyID2, keyID3}}}
 
 	var mbLink1 Metablock
 	if err := mbLink1.Load("foo.2f89b927.link"); err != nil {
@@ -584,9 +584,9 @@ func TestVerifyLinkSignatureThesholds(t *testing.T) {
 	stepsMetadata := []map[string]map[string]Metablock{
 		{"bar": nil},
 		{"foo": nil},
-		{"foo": {keyId1: mbLink1}},
-		{"foo": {keyId1: mbLink1, keyId2: mbLink1}},
-		{"foo": {keyId1: mbLink1, keyId2: mbLinkBroken}},
+		{"foo": {keyID1: mbLink1}},
+		{"foo": {keyID1: mbLink1, keyID2: mbLink1}},
+		{"foo": {keyID1: mbLink1, keyID2: mbLinkBroken}},
 	}
 	for i := 0; i < len(stepsMetadata); i++ {
 		result, err := VerifyLinkSignatureThesholds(layout, stepsMetadata[i])
@@ -600,8 +600,8 @@ func TestVerifyLinkSignatureThesholds(t *testing.T) {
 	// - Threshold 2, two valid links
 	// - Threshold 2, two valid links, one invalid link ignored
 	stepsMetadata = []map[string]map[string]Metablock{
-		{"foo": {keyId1: mbLink1, keyId2: mbLink2}},
-		{"foo": {keyId1: mbLink1, keyId2: mbLink2, keyId3: mbLinkBroken}},
+		{"foo": {keyID1: mbLink1, keyID2: mbLink2}},
+		{"foo": {keyID1: mbLink1, keyID2: mbLink2, keyID3: mbLinkBroken}},
 	}
 	for i := 0; i < len(stepsMetadata); i++ {
 		result, err := VerifyLinkSignatureThesholds(layout, stepsMetadata[i])
@@ -614,8 +614,8 @@ func TestVerifyLinkSignatureThesholds(t *testing.T) {
 }
 
 func TestLoadLinksForLayout(t *testing.T) {
-	keyId1 := "2f89b9272acfc8f4a0a0f094d789fdb0ba798b0fe41f2f5f417c12f0085ff498"
-	keyId2 := "776a00e29f3559e0141b3b096f696abc6cfb0c657ab40f441132b345b08453f5"
+	keyID1 := "2f89b9272acfc8f4a0a0f094d789fdb0ba798b0fe41f2f5f417c12f0085ff498"
+	keyID2 := "776a00e29f3559e0141b3b096f696abc6cfb0c657ab40f441132b345b08453f5"
 	var mb Metablock
 	if err := mb.Load("demo.layout"); err != nil {
 		t.Errorf("Unable to load template file: %s", err)
@@ -625,7 +625,7 @@ func TestLoadLinksForLayout(t *testing.T) {
 	layout.Steps = []Step{{SupplyChainItem: SupplyChainItem{
 		Name: "foo"},
 		Threshold: 2,
-		PubKeys:   []string{keyId1, keyId2}}}
+		PubKeys:   []string{keyID1, keyID2}}}
 
 	// Test successfully load two links for layout (one step foo, threshold 2)
 	result, err := LoadLinksForLayout(layout, ".")
@@ -636,11 +636,11 @@ func TestLoadLinksForLayout(t *testing.T) {
 	}
 
 	// Test threshold error, can't find enough links for step
-	keyId3 := "abcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabca"
+	keyID3 := "abcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabca"
 	layout.Steps = []Step{{SupplyChainItem: SupplyChainItem{
 		Name: "foo"},
 		Threshold: 3,
-		PubKeys:   []string{keyId1, keyId2, keyId3}}}
+		PubKeys:   []string{keyID1, keyID2, keyID3}}}
 	result, err = LoadLinksForLayout(layout, ".")
 	if err == nil {
 		t.Errorf("VerifyLoadLinksForLayout returned (%s, %s), expected"+
@@ -691,7 +691,7 @@ func TestVerifyLayoutSignatures(t *testing.T) {
 	// Test layout signature verification errors:
 	// - Not verification keys (must be at least one)
 	// - No signature found for verification key
-	layoutKeysList := []map[string]Key{{}, {layoutKey.KeyId: Key{}}}
+	layoutKeysList := []map[string]Key{{}, {layoutKey.KeyID: Key{}}}
 	expectedErrors := []string{"at least one key", "No signature found for key"}
 
 	for i := 0; i < len(layoutKeysList); i++ {
@@ -703,7 +703,7 @@ func TestVerifyLayoutSignatures(t *testing.T) {
 	}
 
 	// Test successful layout signature verification
-	err := VerifyLayoutSignatures(mbLayout, map[string]Key{layoutKey.KeyId: layoutKey})
+	err := VerifyLayoutSignatures(mbLayout, map[string]Key{layoutKey.KeyID: layoutKey})
 	if err != nil {
 		t.Errorf("VerifyLayoutSignatures returned '%s', expected nil",
 			err)


### PR DESCRIPTION
- Remove underscore prefix from private function
- Make exposed function private
- Id -> ID
- Json -> JSON
- Fix error strings
- Add docstrings for public members

With these fixes, the only issue I'm seeing in `golint` is the package name.

