### PR TITLE
Tidy go.{mod,sum} after ed25519 change

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,4 @@ module github.com/in-toto/in-toto-golang
 
 go 1.15
 
-require (
-	github.com/shibumi/go-pathspec v1.2.0
-	golang.org/x/crypto v0.0.0-20201112155050-0c6587e931a9
-)
+require github.com/shibumi/go-pathspec v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,2 @@
 github.com/shibumi/go-pathspec v1.2.0 h1:KVKEDHYk7bQolRMs7nfzjT3SBOCgcXFJzccnj9bsGbA=
 github.com/shibumi/go-pathspec v1.2.0/go.mod h1:bDxCftD0fST3qXIlHoQ/fChsU4mWMVklXp1yPErQaaY=
-golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
-golang.org/x/crypto v0.0.0-20201112155050-0c6587e931a9 h1:umElSU9WZirRdgu2yFHY0ayQkEnKiOC1TtM3fWXFnoU=
-golang.org/x/crypto v0.0.0-20201112155050-0c6587e931a9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
*Please fill in the fields below to submit a pull request.  The more
information that is provided, the better.*

**Fixes issue #**: N/A, should have been part of #90


**Description of pull request**: Removes references to golang.org/x/crypto which are unnecessary now that the built-in ed25519 library is used.