### PR TITLE
Add Support for Go 1.16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.15.x]
+        go-version: [1.15.x, 1.16.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/in-toto/in-toto-golang
 
-go 1.15
+go 1.16
 
 require github.com/shibumi/go-pathspec v1.2.0


### PR DESCRIPTION
Go 1.16 has been a released a while ago. This commit updates our Github Actions workflow and introduces a second Go compatibility check for Go 1.16.x. Furthermore it updates our go.mod file accordingly and makes sure we are up to date.

*Please fill in the fields below to submit a pull request.  The more
information that is provided, the better.*

**Fixes issue #**:

Fixes #86 

**Description of pull request**:

This adds CI support for Go 1.16.x and updates our go.mod file accordingly.

**Please verify and check that the pull request fulfills the following
requirements**:

- [X] Tests have been added for the bug fix or new feature
- [X] Docs have been added for the bug fix or new feature


