### PR TITLE
Split the EnvelopeSigner struct into an EnvelopeVerifier struct.

### DIFF
--- a/pkg/ssl/verify.go
+++ b/pkg/ssl/verify.go
@@ -1,0 +1,78 @@
+/*
+Package ssl implements the Secure Systems Lab signing-spec (sometimes
+abbreviated SSL Siging spec.
+https://github.com/secure-systems-lab/signing-spec
+*/
+package ssl
+
+/*
+Verifier verifies a complete message against a signature and key.
+If the message was hashed prior to signature generation, the verifier
+must perform the same steps.
+If the key is not recognized ErrUnknownKey shall be returned.
+*/
+type Verifier interface {
+	Verify(keyID string, data, sig []byte) (bool, error)
+}
+
+type EnvelopeVerifier struct {
+	providers []Verifier
+}
+
+func (ev *EnvelopeVerifier) Verify(e *Envelope) (bool, error) {
+	if len(e.Signatures) == 0 {
+		return false, ErrNoSignature
+	}
+
+	// Decode payload (i.e serialized body)
+	body, err := b64Decode(e.Payload)
+	if err != nil {
+		return false, err
+	}
+	// Generate PAE(payloadtype, serialized body)
+	paeEnc, err := PAE([][]byte{
+		[]byte(e.PayloadType),
+		body,
+	})
+	if err != nil {
+		return false, err
+	}
+
+	// If *any* signature is found to be incorrect, the entire verification
+	// step fails even if *some* signatures are correct.
+	verified := false
+	for _, s := range e.Signatures {
+		sig, err := b64Decode(s.Sig)
+		if err != nil {
+			return false, err
+		}
+
+		// Loop over the providers. If a provider recognizes the key, we exit
+		// the loop and use the result.
+		for _, v := range ev.providers {
+			ok, err := v.Verify(s.KeyID, paeEnc, sig)
+			if err != nil {
+				if err == ErrUnknownKey {
+					continue
+				}
+				return false, err
+			}
+
+			if !ok {
+				return false, nil
+			}
+
+			verified = true
+			break
+		}
+	}
+
+	return verified, nil
+}
+
+func NewEnvelopeVerifier(p ...Verifier) EnvelopeVerifier {
+	ev := EnvelopeVerifier{
+		providers: p,
+	}
+	return ev
+}

--- a/pkg/ssl/verify_test.go
+++ b/pkg/ssl/verify_test.go
@@ -1,0 +1,52 @@
+package ssl
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type mockVerifier struct {
+	returnErr error
+}
+
+func (m *mockVerifier) Verify(keyID string, data, sig []byte) (bool, error) {
+	if m.returnErr != nil {
+		return false, m.returnErr
+	}
+	return true, nil
+}
+
+// Test against the example in the protocol specification:
+// https://github.com/secure-systems-lab/signing-spec/blob/master/protocol.md
+func TestVerify(t *testing.T) {
+	var keyID = "test key 123"
+	var payloadType = "http://example.com/HelloWorld"
+
+	e := Envelope{
+		Payload:     "aGVsbG8gd29ybGQ=",
+		PayloadType: payloadType,
+		Signatures: []Signature{
+			Signature{
+				KeyID: keyID,
+				Sig:   "Cc3RkvYsLhlaFVd+d6FPx4ZClhqW4ZT0rnCYAfv6/ckoGdwT7g/blWNpOBuL/tZhRiVFaglOGTU8GEjm4aEaNA==",
+			},
+		},
+	}
+
+	ev := NewEnvelopeVerifier(&mockVerifier{})
+	ok, err := ev.Verify(&e)
+
+	// Now verify
+	assert.True(t, ok, "verify failed")
+	assert.Nil(t, err, "unexpected error")
+
+	// Now try an error
+	ev = NewEnvelopeVerifier(&mockVerifier{returnErr: errors.New("uh oh")})
+	ok, err = ev.Verify(&e)
+
+	// Now verify
+	assert.False(t, ok, "verify succeeded incorrectly")
+	assert.Error(t, err)
+}


### PR DESCRIPTION
There are use cases where you want to verify without access to the private key,
so this makes it easier!

*Please fill in the fields below to submit a pull request.  The more
information that is provided, the better.*

cc @kommendorkapten 