### PR TITLE
Simplify the EnvelopeSigner interface a bit.

### DIFF
--- a/in_toto/model.go
+++ b/in_toto/model.go
@@ -995,9 +995,9 @@ func (s *SSLSigner) SignPayload(body []byte) (*ssl.Envelope, error) {
 	return s.signer.SignPayload(PayloadType, body)
 }
 
-func (s *SSLSigner) Verify(e *ssl.Envelope) (bool, error) {
+func (s *SSLSigner) Verify(e *ssl.Envelope) error {
 	if e.PayloadType != PayloadType {
-		return false, ErrInvalidPayloadType
+		return ErrInvalidPayloadType
 	}
 
 	return s.signer.Verify(e)

--- a/pkg/ssl/sign.go
+++ b/pkg/ssl/sign.go
@@ -172,7 +172,7 @@ Verify decodes the payload and verifies the signature.
 Any domain specific validation such as parsing the decoded body and
 validating the payload type is left out to the caller.
 */
-func (es *EnvelopeSigner) Verify(e *Envelope) (bool, error) {
+func (es *EnvelopeSigner) Verify(e *Envelope) error {
 	return es.ev.Verify(e)
 }
 

--- a/pkg/ssl/verify.go
+++ b/pkg/ssl/verify.go
@@ -12,22 +12,22 @@ must perform the same steps.
 If the key is not recognized ErrUnknownKey shall be returned.
 */
 type Verifier interface {
-	Verify(keyID string, data, sig []byte) (bool, error)
+	Verify(keyID string, data, sig []byte) error
 }
 
 type EnvelopeVerifier struct {
 	providers []Verifier
 }
 
-func (ev *EnvelopeVerifier) Verify(e *Envelope) (bool, error) {
+func (ev *EnvelopeVerifier) Verify(e *Envelope) error {
 	if len(e.Signatures) == 0 {
-		return false, ErrNoSignature
+		return ErrNoSignature
 	}
 
 	// Decode payload (i.e serialized body)
 	body, err := b64Decode(e.Payload)
 	if err != nil {
-		return false, err
+		return err
 	}
 	// Generate PAE(payloadtype, serialized body)
 	paeEnc, err := PAE([][]byte{
@@ -35,7 +35,7 @@ func (ev *EnvelopeVerifier) Verify(e *Envelope) (bool, error) {
 		body,
 	})
 	if err != nil {
-		return false, err
+		return err
 	}
 
 	// If *any* signature is found to be incorrect, the entire verification
@@ -44,30 +44,29 @@ func (ev *EnvelopeVerifier) Verify(e *Envelope) (bool, error) {
 	for _, s := range e.Signatures {
 		sig, err := b64Decode(s.Sig)
 		if err != nil {
-			return false, err
+			return err
 		}
 
 		// Loop over the providers. If a provider recognizes the key, we exit
 		// the loop and use the result.
 		for _, v := range ev.providers {
-			ok, err := v.Verify(s.KeyID, paeEnc, sig)
+			err := v.Verify(s.KeyID, paeEnc, sig)
 			if err != nil {
 				if err == ErrUnknownKey {
 					continue
 				}
-				return false, err
-			}
-
-			if !ok {
-				return false, nil
+				return err
 			}
 
 			verified = true
 			break
 		}
 	}
+	if !verified {
+		return ErrUnknownKey
+	}
 
-	return verified, nil
+	return nil
 }
 
 func NewEnvelopeVerifier(p ...Verifier) EnvelopeVerifier {

--- a/pkg/ssl/verify_test.go
+++ b/pkg/ssl/verify_test.go
@@ -11,11 +11,11 @@ type mockVerifier struct {
 	returnErr error
 }
 
-func (m *mockVerifier) Verify(keyID string, data, sig []byte) (bool, error) {
+func (m *mockVerifier) Verify(keyID string, data, sig []byte) error {
 	if m.returnErr != nil {
-		return false, m.returnErr
+		return m.returnErr
 	}
-	return true, nil
+	return nil
 }
 
 // Test against the example in the protocol specification:
@@ -36,17 +36,15 @@ func TestVerify(t *testing.T) {
 	}
 
 	ev := NewEnvelopeVerifier(&mockVerifier{})
-	ok, err := ev.Verify(&e)
+	err := ev.Verify(&e)
 
 	// Now verify
-	assert.True(t, ok, "verify failed")
 	assert.Nil(t, err, "unexpected error")
 
 	// Now try an error
 	ev = NewEnvelopeVerifier(&mockVerifier{returnErr: errors.New("uh oh")})
-	ok, err = ev.Verify(&e)
+	err = ev.Verify(&e)
 
 	// Now verify
-	assert.False(t, ok, "verify succeeded incorrectly")
 	assert.Error(t, err)
 }


### PR DESCRIPTION
It was returning (ok, err), which means clients have to remember to check
two things. This feels a little less foot-gun prone, and better aligns
with the crypto stdlib.

*Please fill in the fields below to submit a pull request.  The more
information that is provided, the better.*

**Fixes issue #**:


**Description of pull request**:


**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


