### PR TITLE
make .metadata optional in Provenance statement

### DIFF
--- a/in_toto/model.go
+++ b/in_toto/model.go
@@ -940,7 +940,7 @@ type ProvenanceMaterial struct {
 type ProvenancePredicate struct {
 	Builder   ProvenanceBuilder    `json:"builder"`
 	Recipe    ProvenanceRecipe     `json:"recipe"`
-	Metadata  ProvenanceMetadata   `json:"metadata"`
+	Metadata  *ProvenanceMetadata  `json:"metadata,omitempty"`
 	Materials []ProvenanceMaterial `json:"materials,omitempty"`
 }
 

--- a/in_toto/model_test.go
+++ b/in_toto/model_test.go
@@ -1591,7 +1591,7 @@ func TestDecodeProvenanceStatement(t *testing.T) {
 				DefinedInMaterial: new(int),
 				EntryPoint:        "build.yaml:maketgz",
 			},
-			Metadata: ProvenanceMetadata{
+			Metadata: &ProvenanceMetadata{
 				BuildStartedOn: &testTime,
 				Completeness: ProvenanceComplete{
 					Environment: true,
@@ -1656,7 +1656,7 @@ func TestEncodeProvenanceStatement(t *testing.T) {
 				DefinedInMaterial: new(int),
 				EntryPoint:        "build.yaml:maketgz",
 			},
-			Metadata: ProvenanceMetadata{
+			Metadata: &ProvenanceMetadata{
 				BuildStartedOn:  &testTime,
 				BuildFinishedOn: &testTime,
 				Completeness: ProvenanceComplete{


### PR DESCRIPTION
Signed-off-by: Batuhan Apaydın <batuhan.apaydin@trendyol.com>

*Please fill in the fields below to submit a pull request.  The more
information that is provided, the better.*

**Fixes issue #**:

**Description of pull request**:

We (I and @Dentrax) saw the `.metadata` section is defined as an optional field in the [fields](https://github.com/in-toto/attestation/blob/main/spec/predicates/provenance.md#fields) section of the Provenance documentation, so we should add the `omitempty` tag to it too. This PR aims to fix this problem.

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


