### PR TITLE
Add support for Go 1.17 and deprecate Go 1.15

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.15.x, 1.16.x]
+        go-version: [1.16.x, 1.17.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,16 @@
 module github.com/in-toto/in-toto-golang
 
-go 1.16
+go 1.17
 
 require (
 	github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb
 	github.com/shibumi/go-pathspec v1.2.0
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/sys v0.0.0-20210616094352-59db8d763f22
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/in_toto/util_unix.go
+++ b/in_toto/util_unix.go
@@ -1,3 +1,4 @@
+//go:build linux || darwin || !windows
 // +build linux darwin !windows
 
 package in_toto


### PR DESCRIPTION
Go 1.17 has been released on the 16th of August 2021. Let's deprecate Go 1.15 and follow the Go release cycle.


