### PR TITLE
Add error returns if command invalid in RunCommand #124

### DIFF
--- a/in_toto/runlib.go
+++ b/in_toto/runlib.go
@@ -240,6 +240,10 @@ command execution.
 */
 func RunCommand(cmdArgs []string, runDir string) (map[string]interface{}, error) {
 
+	if cmdArgs == nil || len(cmdArgs) == 0 {
+		return nil, errors.New("invalid command")
+	}
+
 	cmd := exec.Command(cmdArgs[0], cmdArgs[1:]...)
 
 	if runDir != "" {

--- a/in_toto/runlib_test.go
+++ b/in_toto/runlib_test.go
@@ -447,6 +447,8 @@ func TestInTotoRun(t *testing.T) {
 			KeyVal:              KeyVal{},
 			Scheme:              "",
 		}, []string{"sha256"}},
+		{[]string{"alice.pub"}, []string{}, nil, validKey, []string{"sha256"}},
+		{[]string{"alice.pub"}, []string{"foo.tar.gz"}, nil, validKey, []string{"sha256"}},
 	}
 
 	for _, table := range tablesInvalid {


### PR DESCRIPTION
*Please fill in the fields below to submit a pull request.  The more
information that is provided, the better.*

**Fixes issue #**:

Fixes #124 

**Description of pull request**:

RunCommand has not validation to delegate to exec.Command, so I added simple validation that has checked  cmdArgs length and nil.

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature
I consider that it is a trivial bug fix, so I'm not willing to write CHANGE.LOG
If you feel like to write anything in docs, it is welcome for me about this :-)

