### PR TITLE
Move slsa-provenance predicate format into v0.1 package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/in-toto/in-toto-golang
 go 1.17
 
 require (
+	github.com/google/go-cmp v0.5.5
 	github.com/secure-systems-lab/go-securesystemslib v0.1.0
 	github.com/shibumi/go-pathspec v1.2.0
 	github.com/spf13/cobra v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -118,6 +118,7 @@ github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
@@ -457,6 +458,7 @@ golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=

--- a/in_toto/model.go
+++ b/in_toto/model.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"time"
 
-	latest "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.1"
+	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.1"
 
 	"github.com/secure-systems-lab/go-securesystemslib/dsse"
 )
@@ -961,8 +961,8 @@ func (mb *Metablock) Sign(key Key) error {
 
 // Subject describes the set of software artifacts the statement applies to.
 type Subject struct {
-	Name   string           `json:"name"`
-	Digest latest.DigestSet `json:"digest"`
+	Name   string         `json:"name"`
+	Digest slsa.DigestSet `json:"digest"`
 }
 
 // StatementHeader defines the common fields for all statements
@@ -985,7 +985,7 @@ type Statement struct {
 // ProvenanceStatement is the definition for an entire provenance statement.
 type ProvenanceStatement struct {
 	StatementHeader
-	Predicate latest.ProvenancePredicate `json:"predicate"`
+	Predicate slsa.ProvenancePredicate `json:"predicate"`
 }
 
 // LinkStatement is the definition for an entire link statement.

--- a/in_toto/model.go
+++ b/in_toto/model.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 	"time"
 
+	latest "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.1"
+
 	"github.com/secure-systems-lab/go-securesystemslib/dsse"
 )
 
@@ -78,8 +80,6 @@ const (
 	PredicateSPDX = "https://spdx.dev/Document"
 	// PredicateLinkV1 represents an in-toto 0.9 link.
 	PredicateLinkV1 = "https://in-toto.io/Link/v1"
-	// PredicateSLSAProvenanceV01 represents a build provenance for an artifact.
-	PredicateSLSAProvenanceV01 = "https://slsa.dev/provenance/v0.1"
 )
 
 // ErrInvalidPayloadType indicates that the envelope used an unkown payload type
@@ -959,16 +959,10 @@ func (mb *Metablock) Sign(key Key) error {
 	return nil
 }
 
-/*
-DigestSet contains a set of digests. It is represented as a map from
-algorithm name to lowercase hex-encoded value.
-*/
-type DigestSet map[string]string
-
 // Subject describes the set of software artifacts the statement applies to.
 type Subject struct {
-	Name   string    `json:"name"`
-	Digest DigestSet `json:"digest"`
+	Name   string           `json:"name"`
+	Digest latest.DigestSet `json:"digest"`
 }
 
 // StatementHeader defines the common fields for all statements
@@ -988,59 +982,10 @@ type Statement struct {
 	Predicate interface{} `json:"predicate"`
 }
 
-// ProvenanceBuilder idenfifies the entity that executed the build steps.
-type ProvenanceBuilder struct {
-	ID string `json:"id"`
-}
-
-// ProvenanceRecipe describes the actions performed by the builder.
-type ProvenanceRecipe struct {
-	Type string `json:"type"`
-	// DefinedInMaterial can be sent as the null pointer to indicate that
-	// the value is not present.
-	DefinedInMaterial *int        `json:"definedInMaterial,omitempty"`
-	EntryPoint        string      `json:"entryPoint"`
-	Arguments         interface{} `json:"arguments,omitempty"`
-	Environment       interface{} `json:"environment,omitempty"`
-}
-
-// ProvenanceComplete indicates wheter the claims in build/recipe are complete.
-// For in depth information refer to the specifictaion:
-// https://github.com/in-toto/attestation/blob/v0.1.0/spec/predicates/provenance.md
-type ProvenanceComplete struct {
-	Arguments   bool `json:"arguments"`
-	Environment bool `json:"environment"`
-	Materials   bool `json:"materials"`
-}
-
-// ProvenanceMetadata contains metadata for the built artifact.
-type ProvenanceMetadata struct {
-	// Use pointer to make sure that the abscense of a time is not
-	// encoded as the Epoch time.
-	BuildStartedOn  *time.Time         `json:"buildStartedOn,omitempty"`
-	BuildFinishedOn *time.Time         `json:"buildFinishedOn,omitempty"`
-	Completeness    ProvenanceComplete `json:"completeness"`
-	Reproducible    bool               `json:"reproducible"`
-}
-
-// ProvenanceMaterial defines the materials used to build an artifact.
-type ProvenanceMaterial struct {
-	URI    string    `json:"uri"`
-	Digest DigestSet `json:"digest,omitempty"`
-}
-
-// ProvenancePredicate is the provenance predicate definition.
-type ProvenancePredicate struct {
-	Builder   ProvenanceBuilder    `json:"builder"`
-	Recipe    ProvenanceRecipe     `json:"recipe"`
-	Metadata  *ProvenanceMetadata  `json:"metadata,omitempty"`
-	Materials []ProvenanceMaterial `json:"materials,omitempty"`
-}
-
 // ProvenanceStatement is the definition for an entire provenance statement.
 type ProvenanceStatement struct {
 	StatementHeader
-	Predicate ProvenancePredicate `json:"predicate"`
+	Predicate latest.ProvenancePredicate `json:"predicate"`
 }
 
 // LinkStatement is the definition for an entire link statement.

--- a/in_toto/model_test.go
+++ b/in_toto/model_test.go
@@ -15,7 +15,8 @@ import (
 	"testing"
 	"time"
 
-	latest "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.1"
+	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.1"
+
 	"github.com/secure-systems-lab/go-securesystemslib/dsse"
 	"github.com/stretchr/testify/assert"
 )
@@ -1558,41 +1559,41 @@ func TestDecodeProvenanceStatement(t *testing.T) {
 	var want = ProvenanceStatement{
 		StatementHeader: StatementHeader{
 			Type:          StatementInTotoV01,
-			PredicateType: latest.PredicateSLSAProvenance,
+			PredicateType: slsa.PredicateSLSAProvenance,
 			Subject: []Subject{
 				{
 					Name: "curl-7.72.0.tar.bz2",
-					Digest: latest.DigestSet{
+					Digest: slsa.DigestSet{
 						"sha256": "ad91970864102a59765e20ce16216efc9d6ad381471f7accceceab7d905703ef",
 					},
 				},
 				{
 					Name: "curl-7.72.0.tar.gz",
-					Digest: latest.DigestSet{
+					Digest: slsa.DigestSet{
 						"sha256": "d4d5899a3868fbb6ae1856c3e55a32ce35913de3956d1973caccd37bd0174fa2",
 					},
 				},
 			},
 		},
-		Predicate: latest.ProvenancePredicate{
-			Builder: latest.ProvenanceBuilder{
+		Predicate: slsa.ProvenancePredicate{
+			Builder: slsa.ProvenanceBuilder{
 				ID: "https://github.com/Attestations/GitHubHostedActions@v1",
 			},
-			Recipe: latest.ProvenanceRecipe{
+			Recipe: slsa.ProvenanceRecipe{
 				Type:              "https://github.com/Attestations/GitHubActionsWorkflow@v1",
 				DefinedInMaterial: new(int),
 				EntryPoint:        "build.yaml:maketgz",
 			},
-			Metadata: &latest.ProvenanceMetadata{
+			Metadata: &slsa.ProvenanceMetadata{
 				BuildStartedOn: &testTime,
-				Completeness: latest.ProvenanceComplete{
+				Completeness: slsa.ProvenanceComplete{
 					Environment: true,
 				},
 			},
-			Materials: []latest.ProvenanceMaterial{
+			Materials: []slsa.ProvenanceMaterial{
 				{
 					URI: "git+https://github.com/curl/curl-docker@master",
-					Digest: latest.DigestSet{
+					Digest: slsa.DigestSet{
 						"sha1": "d6525c840a62b398424a78d792f457477135d0cf",
 					},
 				},
@@ -1623,44 +1624,44 @@ func TestEncodeProvenanceStatement(t *testing.T) {
 	var p = ProvenanceStatement{
 		StatementHeader: StatementHeader{
 			Type:          StatementInTotoV01,
-			PredicateType: latest.PredicateSLSAProvenance,
+			PredicateType: slsa.PredicateSLSAProvenance,
 			Subject: []Subject{
 				{
 					Name: "curl-7.72.0.tar.bz2",
-					Digest: latest.DigestSet{
+					Digest: slsa.DigestSet{
 						"sha256": "ad91970864102a59765e20ce16216efc9d6ad381471f7accceceab7d905703ef",
 					},
 				},
 				{
 					Name: "curl-7.72.0.tar.gz",
-					Digest: latest.DigestSet{
+					Digest: slsa.DigestSet{
 						"sha256": "d4d5899a3868fbb6ae1856c3e55a32ce35913de3956d1973caccd37bd0174fa2",
 					},
 				},
 			},
 		},
-		Predicate: latest.ProvenancePredicate{
-			Builder: latest.ProvenanceBuilder{
+		Predicate: slsa.ProvenancePredicate{
+			Builder: slsa.ProvenanceBuilder{
 				ID: "https://github.com/Attestations/GitHubHostedActions@v1",
 			},
-			Recipe: latest.ProvenanceRecipe{
+			Recipe: slsa.ProvenanceRecipe{
 				Type:              "https://github.com/Attestations/GitHubActionsWorkflow@v1",
 				DefinedInMaterial: new(int),
 				EntryPoint:        "build.yaml:maketgz",
 			},
-			Metadata: &latest.ProvenanceMetadata{
+			Metadata: &slsa.ProvenanceMetadata{
 				BuildStartedOn:  &testTime,
 				BuildFinishedOn: &testTime,
-				Completeness: latest.ProvenanceComplete{
+				Completeness: slsa.ProvenanceComplete{
 					Arguments:   true,
 					Environment: false,
 					Materials:   true,
 				},
 			},
-			Materials: []latest.ProvenanceMaterial{
+			Materials: []slsa.ProvenanceMaterial{
 				{
 					URI: "git+https://github.com/curl/curl-docker@master",
-					Digest: latest.DigestSet{
+					Digest: slsa.DigestSet{
 						"sha1": "d6525c840a62b398424a78d792f457477135d0cf",
 					},
 				},
@@ -1683,14 +1684,14 @@ func TestEncodeProvenanceStatement(t *testing.T) {
 // Test that the default date (January 1, year 1, 00:00:00 UTC) is
 // not marshalled
 func TestMetadataNoTime(t *testing.T) {
-	var md = latest.ProvenanceMetadata{
-		Completeness: latest.ProvenanceComplete{
+	var md = slsa.ProvenanceMetadata{
+		Completeness: slsa.ProvenanceComplete{
 			Arguments: true,
 		},
 		Reproducible: true,
 	}
 	var want = `{"completeness":{"arguments":true,"environment":false,"materials":false},"reproducible":true}`
-	var got latest.ProvenanceMetadata
+	var got slsa.ProvenanceMetadata
 	b, err := json.Marshal(&md)
 
 	t.Run("Marshal", func(t *testing.T) {
@@ -1708,12 +1709,12 @@ func TestMetadataNoTime(t *testing.T) {
 // Verify that the behaviour of definedInMaterial can be controlled,
 // as there is a semantic difference in value present or 0.
 func TestRecipe(t *testing.T) {
-	var r = latest.ProvenanceRecipe{
+	var r = slsa.ProvenanceRecipe{
 		Type:       "testType",
 		EntryPoint: "testEntry",
 	}
 	var want = `{"type":"testType","entryPoint":"testEntry"}`
-	var got latest.ProvenanceRecipe
+	var got slsa.ProvenanceRecipe
 	b, err := json.Marshal(&r)
 
 	t.Run("No time/marshal", func(t *testing.T) {
@@ -1778,7 +1779,7 @@ func TestLinkStatement(t *testing.T) {
 			Subject: []Subject{
 				{
 					Name: "baz",
-					Digest: latest.DigestSet{
+					Digest: slsa.DigestSet{
 						"sha256": "hash1",
 					},
 				},

--- a/in_toto/model_test.go
+++ b/in_toto/model_test.go
@@ -15,8 +15,8 @@ import (
 	"testing"
 	"time"
 
+	latest "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.1"
 	"github.com/secure-systems-lab/go-securesystemslib/dsse"
-
 	"github.com/stretchr/testify/assert"
 )
 
@@ -1558,41 +1558,41 @@ func TestDecodeProvenanceStatement(t *testing.T) {
 	var want = ProvenanceStatement{
 		StatementHeader: StatementHeader{
 			Type:          StatementInTotoV01,
-			PredicateType: PredicateSLSAProvenanceV01,
+			PredicateType: latest.PredicateSLSAProvenance,
 			Subject: []Subject{
 				{
 					Name: "curl-7.72.0.tar.bz2",
-					Digest: DigestSet{
+					Digest: latest.DigestSet{
 						"sha256": "ad91970864102a59765e20ce16216efc9d6ad381471f7accceceab7d905703ef",
 					},
 				},
 				{
 					Name: "curl-7.72.0.tar.gz",
-					Digest: DigestSet{
+					Digest: latest.DigestSet{
 						"sha256": "d4d5899a3868fbb6ae1856c3e55a32ce35913de3956d1973caccd37bd0174fa2",
 					},
 				},
 			},
 		},
-		Predicate: ProvenancePredicate{
-			Builder: ProvenanceBuilder{
+		Predicate: latest.ProvenancePredicate{
+			Builder: latest.ProvenanceBuilder{
 				ID: "https://github.com/Attestations/GitHubHostedActions@v1",
 			},
-			Recipe: ProvenanceRecipe{
+			Recipe: latest.ProvenanceRecipe{
 				Type:              "https://github.com/Attestations/GitHubActionsWorkflow@v1",
 				DefinedInMaterial: new(int),
 				EntryPoint:        "build.yaml:maketgz",
 			},
-			Metadata: &ProvenanceMetadata{
+			Metadata: &latest.ProvenanceMetadata{
 				BuildStartedOn: &testTime,
-				Completeness: ProvenanceComplete{
+				Completeness: latest.ProvenanceComplete{
 					Environment: true,
 				},
 			},
-			Materials: []ProvenanceMaterial{
+			Materials: []latest.ProvenanceMaterial{
 				{
 					URI: "git+https://github.com/curl/curl-docker@master",
-					Digest: DigestSet{
+					Digest: latest.DigestSet{
 						"sha1": "d6525c840a62b398424a78d792f457477135d0cf",
 					},
 				},
@@ -1623,44 +1623,44 @@ func TestEncodeProvenanceStatement(t *testing.T) {
 	var p = ProvenanceStatement{
 		StatementHeader: StatementHeader{
 			Type:          StatementInTotoV01,
-			PredicateType: PredicateSLSAProvenanceV01,
+			PredicateType: latest.PredicateSLSAProvenance,
 			Subject: []Subject{
 				{
 					Name: "curl-7.72.0.tar.bz2",
-					Digest: DigestSet{
+					Digest: latest.DigestSet{
 						"sha256": "ad91970864102a59765e20ce16216efc9d6ad381471f7accceceab7d905703ef",
 					},
 				},
 				{
 					Name: "curl-7.72.0.tar.gz",
-					Digest: DigestSet{
+					Digest: latest.DigestSet{
 						"sha256": "d4d5899a3868fbb6ae1856c3e55a32ce35913de3956d1973caccd37bd0174fa2",
 					},
 				},
 			},
 		},
-		Predicate: ProvenancePredicate{
-			Builder: ProvenanceBuilder{
+		Predicate: latest.ProvenancePredicate{
+			Builder: latest.ProvenanceBuilder{
 				ID: "https://github.com/Attestations/GitHubHostedActions@v1",
 			},
-			Recipe: ProvenanceRecipe{
+			Recipe: latest.ProvenanceRecipe{
 				Type:              "https://github.com/Attestations/GitHubActionsWorkflow@v1",
 				DefinedInMaterial: new(int),
 				EntryPoint:        "build.yaml:maketgz",
 			},
-			Metadata: &ProvenanceMetadata{
+			Metadata: &latest.ProvenanceMetadata{
 				BuildStartedOn:  &testTime,
 				BuildFinishedOn: &testTime,
-				Completeness: ProvenanceComplete{
+				Completeness: latest.ProvenanceComplete{
 					Arguments:   true,
 					Environment: false,
 					Materials:   true,
 				},
 			},
-			Materials: []ProvenanceMaterial{
+			Materials: []latest.ProvenanceMaterial{
 				{
 					URI: "git+https://github.com/curl/curl-docker@master",
-					Digest: DigestSet{
+					Digest: latest.DigestSet{
 						"sha1": "d6525c840a62b398424a78d792f457477135d0cf",
 					},
 				},
@@ -1683,14 +1683,14 @@ func TestEncodeProvenanceStatement(t *testing.T) {
 // Test that the default date (January 1, year 1, 00:00:00 UTC) is
 // not marshalled
 func TestMetadataNoTime(t *testing.T) {
-	var md = ProvenanceMetadata{
-		Completeness: ProvenanceComplete{
+	var md = latest.ProvenanceMetadata{
+		Completeness: latest.ProvenanceComplete{
 			Arguments: true,
 		},
 		Reproducible: true,
 	}
 	var want = `{"completeness":{"arguments":true,"environment":false,"materials":false},"reproducible":true}`
-	var got ProvenanceMetadata
+	var got latest.ProvenanceMetadata
 	b, err := json.Marshal(&md)
 
 	t.Run("Marshal", func(t *testing.T) {
@@ -1708,12 +1708,12 @@ func TestMetadataNoTime(t *testing.T) {
 // Verify that the behaviour of definedInMaterial can be controlled,
 // as there is a semantic difference in value present or 0.
 func TestRecipe(t *testing.T) {
-	var r = ProvenanceRecipe{
+	var r = latest.ProvenanceRecipe{
 		Type:       "testType",
 		EntryPoint: "testEntry",
 	}
 	var want = `{"type":"testType","entryPoint":"testEntry"}`
-	var got ProvenanceRecipe
+	var got latest.ProvenanceRecipe
 	b, err := json.Marshal(&r)
 
 	t.Run("No time/marshal", func(t *testing.T) {
@@ -1778,7 +1778,7 @@ func TestLinkStatement(t *testing.T) {
 			Subject: []Subject{
 				{
 					Name: "baz",
-					Digest: DigestSet{
+					Digest: latest.DigestSet{
 						"sha256": "hash1",
 					},
 				},

--- a/in_toto/slsa_provenance/v0.1/provenance.go
+++ b/in_toto/slsa_provenance/v0.1/provenance.go
@@ -56,8 +56,6 @@ type ProvenanceComplete struct {
 	Materials   bool `json:"materials"`
 }
 
-/*
-DigestSet contains a set of digests. It is represented as a map from
-algorithm name to lowercase hex-encoded value.
-*/
+// DigestSet contains a set of digests. It is represented as a map from
+// algorithm name to lowercase hex-encoded value.
 type DigestSet map[string]string

--- a/in_toto/slsa_provenance/v0.1/provenance.go
+++ b/in_toto/slsa_provenance/v0.1/provenance.go
@@ -1,0 +1,63 @@
+package v01
+
+import "time"
+
+const (
+	// PredicateSLSAProvenance represents a build provenance for an artifact.
+	PredicateSLSAProvenance = "https://slsa.dev/provenance/v0.1"
+)
+
+// ProvenancePredicate is the provenance predicate definition.
+type ProvenancePredicate struct {
+	Builder   ProvenanceBuilder    `json:"builder"`
+	Recipe    ProvenanceRecipe     `json:"recipe"`
+	Metadata  *ProvenanceMetadata  `json:"metadata,omitempty"`
+	Materials []ProvenanceMaterial `json:"materials,omitempty"`
+}
+
+// ProvenanceBuilder idenfifies the entity that executed the build steps.
+type ProvenanceBuilder struct {
+	ID string `json:"id"`
+}
+
+// ProvenanceRecipe describes the actions performed by the builder.
+type ProvenanceRecipe struct {
+	Type string `json:"type"`
+	// DefinedInMaterial can be sent as the null pointer to indicate that
+	// the value is not present.
+	DefinedInMaterial *int        `json:"definedInMaterial,omitempty"`
+	EntryPoint        string      `json:"entryPoint"`
+	Arguments         interface{} `json:"arguments,omitempty"`
+	Environment       interface{} `json:"environment,omitempty"`
+}
+
+// ProvenanceMetadata contains metadata for the built artifact.
+type ProvenanceMetadata struct {
+	// Use pointer to make sure that the abscense of a time is not
+	// encoded as the Epoch time.
+	BuildStartedOn  *time.Time         `json:"buildStartedOn,omitempty"`
+	BuildFinishedOn *time.Time         `json:"buildFinishedOn,omitempty"`
+	Completeness    ProvenanceComplete `json:"completeness"`
+	Reproducible    bool               `json:"reproducible"`
+}
+
+// ProvenanceMaterial defines the materials used to build an artifact.
+type ProvenanceMaterial struct {
+	URI    string    `json:"uri"`
+	Digest DigestSet `json:"digest,omitempty"`
+}
+
+// ProvenanceComplete indicates wheter the claims in build/recipe are complete.
+// For in depth information refer to the specifictaion:
+// https://github.com/in-toto/attestation/blob/v0.1.0/spec/predicates/provenance.md
+type ProvenanceComplete struct {
+	Arguments   bool `json:"arguments"`
+	Environment bool `json:"environment"`
+	Materials   bool `json:"materials"`
+}
+
+/*
+DigestSet contains a set of digests. It is represented as a map from
+algorithm name to lowercase hex-encoded value.
+*/
+type DigestSet map[string]string

--- a/in_toto/slsa_provenance/v0.1/provenance_test.go
+++ b/in_toto/slsa_provenance/v0.1/provenance_test.go
@@ -1,0 +1,189 @@
+package v01
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDecodeProvenancePredicate(t *testing.T) {
+	// Data from example in specification for generalized link format,
+	// subject and materials trimmed.
+	var data = `
+{
+    "builder": { "id": "https://github.com/Attestations/GitHubHostedActions@v1" },
+    "recipe": {
+      "type": "https://github.com/Attestations/GitHubActionsWorkflow@v1",
+      "definedInMaterial": 0,
+      "entryPoint": "build.yaml:maketgz"
+    },
+    "metadata": {
+      "buildStartedOn": "2020-08-19T08:38:00Z",
+      "completeness": {
+          "environment": true
+      }
+    },
+    "materials": [
+      {
+        "uri": "git+https://github.com/curl/curl-docker@master",
+        "digest": { "sha1": "d6525c840a62b398424a78d792f457477135d0cf" }
+      }, {
+        "uri": "github_hosted_vm:ubuntu-18.04:20210123.1"
+      }
+    ]
+}
+`
+	var testTime = time.Unix(1597826280, 0)
+	var want = ProvenancePredicate{
+		Builder: ProvenanceBuilder{
+			ID: "https://github.com/Attestations/GitHubHostedActions@v1",
+		},
+		Recipe: ProvenanceRecipe{
+			Type:              "https://github.com/Attestations/GitHubActionsWorkflow@v1",
+			DefinedInMaterial: new(int),
+			EntryPoint:        "build.yaml:maketgz",
+		},
+		Metadata: &ProvenanceMetadata{
+			BuildStartedOn: &testTime,
+			Completeness: ProvenanceComplete{
+				Environment: true,
+			},
+		},
+		Materials: []ProvenanceMaterial{
+			{
+				URI: "git+https://github.com/curl/curl-docker@master",
+				Digest: DigestSet{
+					"sha1": "d6525c840a62b398424a78d792f457477135d0cf",
+				},
+			},
+			{
+				URI: "github_hosted_vm:ubuntu-18.04:20210123.1",
+			},
+		},
+	}
+	var got ProvenancePredicate
+
+	if err := json.Unmarshal([]byte(data), &got); err != nil {
+		t.Errorf("failed to unmarshal json: %s\n", err)
+		return
+	}
+
+	// Make sure parsed time have same location set, location is only used
+	// for display purposes.
+	loc := want.Metadata.BuildStartedOn.Location()
+	tmp := got.Metadata.BuildStartedOn.In(loc)
+	got.Metadata.BuildStartedOn = &tmp
+
+	assert.Equal(t, want, got, "Unexpected object after decoding")
+}
+
+func TestEncodeProvenancePredicate(t *testing.T) {
+	var testTime = time.Unix(1597826280, 0)
+	var p = ProvenancePredicate{
+		Builder: ProvenanceBuilder{
+			ID: "https://github.com/Attestations/GitHubHostedActions@v1",
+		},
+		Recipe: ProvenanceRecipe{
+			Type:              "https://github.com/Attestations/GitHubActionsWorkflow@v1",
+			DefinedInMaterial: new(int),
+			EntryPoint:        "build.yaml:maketgz",
+		},
+		Metadata: &ProvenanceMetadata{
+			BuildStartedOn:  &testTime,
+			BuildFinishedOn: &testTime,
+			Completeness: ProvenanceComplete{
+				Arguments:   true,
+				Environment: false,
+				Materials:   true,
+			},
+		},
+		Materials: []ProvenanceMaterial{
+			{
+				URI: "git+https://github.com/curl/curl-docker@master",
+				Digest: DigestSet{
+					"sha1": "d6525c840a62b398424a78d792f457477135d0cf",
+				},
+			},
+			{
+				URI: "github_hosted_vm:ubuntu-18.04:20210123.1",
+			},
+			{
+				URI: "git+https://github.com/curl/",
+			},
+		},
+	}
+	var want = `{"builder":{"id":"https://github.com/Attestations/GitHubHostedActions@v1"},"recipe":{"type":"https://github.com/Attestations/GitHubActionsWorkflow@v1","definedInMaterial":0,"entryPoint":"build.yaml:maketgz"},"metadata":{"buildStartedOn":"2020-08-19T08:38:00Z","buildFinishedOn":"2020-08-19T08:38:00Z","completeness":{"arguments":true,"environment":false,"materials":true},"reproducible":false},"materials":[{"uri":"git+https://github.com/curl/curl-docker@master","digest":{"sha1":"d6525c840a62b398424a78d792f457477135d0cf"}},{"uri":"github_hosted_vm:ubuntu-18.04:20210123.1"},{"uri":"git+https://github.com/curl/"}]}`
+	b, err := json.Marshal(&p)
+	assert.Nil(t, err, "Error during JSON marshal")
+	if d := cmp.Diff(want, string(b)); d != "" {
+		t.Fatal(d)
+	}
+	assert.Equal(t, want, string(b), "Wrong JSON produced")
+}
+
+// Test that the default date (January 1, year 1, 00:00:00 UTC) is
+// not marshalled
+func TestMetadataNoTime(t *testing.T) {
+	var md = ProvenanceMetadata{
+		Completeness: ProvenanceComplete{
+			Arguments: true,
+		},
+		Reproducible: true,
+	}
+	var want = `{"completeness":{"arguments":true,"environment":false,"materials":false},"reproducible":true}`
+	var got ProvenanceMetadata
+	b, err := json.Marshal(&md)
+
+	t.Run("Marshal", func(t *testing.T) {
+		assert.Nil(t, err, "Error during JSON marshal")
+		assert.Equal(t, want, string(b), "Wrong JSON produced")
+	})
+
+	t.Run("Unmashal", func(t *testing.T) {
+		err := json.Unmarshal(b, &got)
+		assert.Nil(t, err, "Error during JSON unmarshal")
+		assert.Equal(t, md, got, "Wrong struct after JSON unmarshal")
+	})
+}
+
+// Verify that the behaviour of definedInMaterial can be controlled,
+// as there is a semantic difference in value present or 0.
+func TestRecipe(t *testing.T) {
+	var r = ProvenanceRecipe{
+		Type:       "testType",
+		EntryPoint: "testEntry",
+	}
+	var want = `{"type":"testType","entryPoint":"testEntry"}`
+	var got ProvenanceRecipe
+	b, err := json.Marshal(&r)
+
+	t.Run("No time/marshal", func(t *testing.T) {
+		assert.Nil(t, err, "Error during JSON marshal")
+		assert.Equal(t, want, string(b), "Wrong JSON produced")
+	})
+
+	t.Run("No time/unmarshal", func(t *testing.T) {
+		err = json.Unmarshal(b, &got)
+		assert.Nil(t, err, "Error during JSON unmarshal")
+		assert.Equal(t, r, got, "Wrong struct after JSON unmarshal")
+	})
+
+	// Set time to zero and run test again
+	r.DefinedInMaterial = new(int)
+	want = `{"type":"testType","definedInMaterial":0,"entryPoint":"testEntry"}`
+	b, err = json.Marshal(&r)
+
+	t.Run("With time/marshal", func(t *testing.T) {
+		assert.Nil(t, err, "Error during JSON marshal")
+		assert.Equal(t, want, string(b), "Wrong JSON produced")
+	})
+
+	t.Run("With time/unmarshal", func(t *testing.T) {
+		err = json.Unmarshal(b, &got)
+		assert.Nil(t, err, "Error during JSON unmarshal")
+		assert.Equal(t, r, got, "Wrong struct after JSON unmarshal")
+	})
+}


### PR DESCRIPTION
**Fixes issue:**
I'm working on merging in a proposal for v0.2 for the `slsa-provenance` predicate format (https://github.com/slsa-framework/slsa/pull/179). Once that's in, I was planning on adding the new version to this repo. There doesn't seem to be a way to version the [ProvenancePredicate](https://github.com/in-toto/in-toto-golang/blob/master/in_toto/model.go#L1033) so I moved the slsa-provenance predicate to a v0.1 directory. 

**Description:**
I moved the predicate model to `pkg/in_toto/slsa_provenance/v0.1`. When adding in new versions, we can create `v0.x` directories as needed. I also named the import to this package in `models.go` as `latest`, so only the import needs to be updated as new versions are added. 

Feedback would be appreciated if someone has a better way to do this! 

**Please verify and check that the pull request fulfills the following
requirements:**

- [x] Tests have been added for the bug fix or new feature


