### PR TITLE
Add slsa0.1 statement struct back

### DIFF
--- a/in_toto/model.go
+++ b/in_toto/model.go
@@ -15,7 +15,9 @@ import (
 	"strings"
 	"time"
 
-	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
+	"github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
+	slsa01 "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.1"
+	slsa02 "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
 
 	"github.com/secure-systems-lab/go-securesystemslib/cjson"
 	"github.com/secure-systems-lab/go-securesystemslib/dsse"
@@ -964,8 +966,8 @@ func (mb *Metablock) Sign(key Key) error {
 
 // Subject describes the set of software artifacts the statement applies to.
 type Subject struct {
-	Name   string         `json:"name"`
-	Digest slsa.DigestSet `json:"digest"`
+	Name   string           `json:"name"`
+	Digest common.DigestSet `json:"digest"`
 }
 
 // StatementHeader defines the common fields for all statements
@@ -985,10 +987,23 @@ type Statement struct {
 	Predicate interface{} `json:"predicate"`
 }
 
-// ProvenanceStatement is the definition for an entire provenance statement.
+// ProvenanceStatementSLSA01 is the definition for an entire provenance statement with SLSA 0.1 predicate.
+type ProvenanceStatementSLSA01 struct {
+	StatementHeader
+	Predicate slsa01.ProvenancePredicate `json:"predicate"`
+}
+
+// ProvenanceStatementSLSA02 is the definition for an entire provenance statement with SLSA 0.2 predicate.
+type ProvenanceStatementSLSA02 struct {
+	StatementHeader
+	Predicate slsa02.ProvenancePredicate `json:"predicate"`
+}
+
+// ProvenanceStatement is the definition for an entire provenance statement with SLSA 0.2 predicate.
+// Deprecated: Only version-specific provenance structs will be maintained (ProvenanceStatementSLSA01, ProvenanceStatementSLSA02).
 type ProvenanceStatement struct {
 	StatementHeader
-	Predicate slsa.ProvenancePredicate `json:"predicate"`
+	Predicate slsa02.ProvenancePredicate `json:"predicate"`
 }
 
 // LinkStatement is the definition for an entire link statement.

--- a/in_toto/model_test.go
+++ b/in_toto/model_test.go
@@ -16,7 +16,9 @@ import (
 	"testing"
 	"time"
 
-	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
+	"github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
+	slsa01 "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.1"
+	slsa02 "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
 
 	"github.com/secure-systems-lab/go-securesystemslib/dsse"
 	"github.com/stretchr/testify/assert"
@@ -1518,7 +1520,7 @@ func TestValidatePublicKey(t *testing.T) {
 	}
 }
 
-func TestDecodeProvenanceStatement(t *testing.T) {
+func TestDecodeProvenanceStatementSLSA02(t *testing.T) {
 	// Data from example in specification for generalized link format,
 	// subject and materials trimmed.
 	var data = `
@@ -1563,46 +1565,46 @@ func TestDecodeProvenanceStatement(t *testing.T) {
 	var want = ProvenanceStatement{
 		StatementHeader: StatementHeader{
 			Type:          StatementInTotoV01,
-			PredicateType: slsa.PredicateSLSAProvenance,
+			PredicateType: slsa02.PredicateSLSAProvenance,
 			Subject: []Subject{
 				{
 					Name: "curl-7.72.0.tar.bz2",
-					Digest: slsa.DigestSet{
+					Digest: common.DigestSet{
 						"sha256": "ad91970864102a59765e20ce16216efc9d6ad381471f7accceceab7d905703ef",
 					},
 				},
 				{
 					Name: "curl-7.72.0.tar.gz",
-					Digest: slsa.DigestSet{
+					Digest: common.DigestSet{
 						"sha256": "d4d5899a3868fbb6ae1856c3e55a32ce35913de3956d1973caccd37bd0174fa2",
 					},
 				},
 			},
 		},
-		Predicate: slsa.ProvenancePredicate{
-			Builder: slsa.ProvenanceBuilder{
+		Predicate: slsa02.ProvenancePredicate{
+			Builder: common.ProvenanceBuilder{
 				ID: "https://github.com/Attestations/GitHubHostedActions@v1",
 			},
 			BuildType: "https://github.com/Attestations/GitHubActionsWorkflow@v1",
-			Invocation: slsa.ProvenanceInvocation{
-				ConfigSource: slsa.ConfigSource{
+			Invocation: slsa02.ProvenanceInvocation{
+				ConfigSource: slsa02.ConfigSource{
 					EntryPoint: "build.yaml:maketgz",
 					URI:        "git+https://github.com/curl/curl-docker@master",
-					Digest: slsa.DigestSet{
+					Digest: common.DigestSet{
 						"sha1": "d6525c840a62b398424a78d792f457477135d0cf",
 					},
 				},
 			},
-			Metadata: &slsa.ProvenanceMetadata{
+			Metadata: &slsa02.ProvenanceMetadata{
 				BuildStartedOn: &testTime,
-				Completeness: slsa.ProvenanceComplete{
+				Completeness: slsa02.ProvenanceComplete{
 					Environment: true,
 				},
 			},
-			Materials: []slsa.ProvenanceMaterial{
+			Materials: []common.ProvenanceMaterial{
 				{
 					URI: "git+https://github.com/curl/curl-docker@master",
-					Digest: slsa.DigestSet{
+					Digest: common.DigestSet{
 						"sha1": "d6525c840a62b398424a78d792f457477135d0cf",
 					},
 				},
@@ -1628,54 +1630,54 @@ func TestDecodeProvenanceStatement(t *testing.T) {
 	assert.Equal(t, want, got, "Unexpexted object after decoding")
 }
 
-func TestEncodeProvenanceStatement(t *testing.T) {
+func TestEncodeProvenanceStatementSLSA02(t *testing.T) {
 	var testTime = time.Unix(1597826280, 0)
 	var p = ProvenanceStatement{
 		StatementHeader: StatementHeader{
 			Type:          StatementInTotoV01,
-			PredicateType: slsa.PredicateSLSAProvenance,
+			PredicateType: slsa02.PredicateSLSAProvenance,
 			Subject: []Subject{
 				{
 					Name: "curl-7.72.0.tar.bz2",
-					Digest: slsa.DigestSet{
+					Digest: common.DigestSet{
 						"sha256": "ad91970864102a59765e20ce16216efc9d6ad381471f7accceceab7d905703ef",
 					},
 				},
 				{
 					Name: "curl-7.72.0.tar.gz",
-					Digest: slsa.DigestSet{
+					Digest: common.DigestSet{
 						"sha256": "d4d5899a3868fbb6ae1856c3e55a32ce35913de3956d1973caccd37bd0174fa2",
 					},
 				},
 			},
 		},
-		Predicate: slsa.ProvenancePredicate{
-			Builder: slsa.ProvenanceBuilder{
+		Predicate: slsa02.ProvenancePredicate{
+			Builder: common.ProvenanceBuilder{
 				ID: "https://github.com/Attestations/GitHubHostedActions@v1",
 			},
 			BuildType: "https://github.com/Attestations/GitHubActionsWorkflow@v1",
-			Invocation: slsa.ProvenanceInvocation{
-				ConfigSource: slsa.ConfigSource{
+			Invocation: slsa02.ProvenanceInvocation{
+				ConfigSource: slsa02.ConfigSource{
 					URI: "git+https://github.com/curl/curl-docker@master",
-					Digest: slsa.DigestSet{
+					Digest: common.DigestSet{
 						"sha1": "d6525c840a62b398424a78d792f457477135d0cf",
 					},
 					EntryPoint: "build.yaml:maketgz",
 				},
 			},
-			Metadata: &slsa.ProvenanceMetadata{
+			Metadata: &slsa02.ProvenanceMetadata{
 				BuildStartedOn:  &testTime,
 				BuildFinishedOn: &testTime,
-				Completeness: slsa.ProvenanceComplete{
+				Completeness: slsa02.ProvenanceComplete{
 					Parameters:  true,
 					Environment: false,
 					Materials:   true,
 				},
 			},
-			Materials: []slsa.ProvenanceMaterial{
+			Materials: []common.ProvenanceMaterial{
 				{
 					URI: "git+https://github.com/curl/curl-docker@master",
-					Digest: slsa.DigestSet{
+					Digest: common.DigestSet{
 						"sha1": "d6525c840a62b398424a78d792f457477135d0cf",
 					},
 				},
@@ -1695,17 +1697,181 @@ func TestEncodeProvenanceStatement(t *testing.T) {
 	assert.Equal(t, want, string(b), "Wrong JSON produced")
 }
 
+func TestDecodeProvenanceStatementSLSA01(t *testing.T) {
+	// Data from example in specification for generalized link format,
+	// subject and materials trimmed.
+	var data = `
+{
+  "_type": "https://in-toto.io/Statement/v0.1",
+  "subject": [
+    { "name": "curl-7.72.0.tar.bz2",
+      "digest": { "sha256": "ad91970864102a59765e20ce16216efc9d6ad381471f7accceceab7d905703ef" }},
+    { "name": "curl-7.72.0.tar.gz",
+      "digest": { "sha256": "d4d5899a3868fbb6ae1856c3e55a32ce35913de3956d1973caccd37bd0174fa2" }}
+  ],
+  "predicateType": "https://slsa.dev/provenance/v0.1",
+  "predicate": {
+    "builder": { "id": "https://github.com/Attestations/GitHubHostedActions@v1" },
+    "recipe": {
+      "type": "https://github.com/Attestations/GitHubActionsWorkflow@v1",
+      "definedInMaterial": 0,
+      "entryPoint": "build.yaml:maketgz"
+    },
+    "metadata": {
+      "buildStartedOn": "2020-08-19T08:38:00Z",
+      "completeness": {
+          "environment": true
+      }
+    },
+    "materials": [
+      {
+        "uri": "git+https://github.com/curl/curl-docker@master",
+        "digest": { "sha1": "d6525c840a62b398424a78d792f457477135d0cf" }
+      }, {
+        "uri": "github_hosted_vm:ubuntu-18.04:20210123.1"
+      }
+    ]
+  }
+}
+`
+
+	var testTime = time.Unix(1597826280, 0)
+	var want = ProvenanceStatementSLSA01{
+		StatementHeader: StatementHeader{
+			Type:          StatementInTotoV01,
+			PredicateType: slsa01.PredicateSLSAProvenance,
+			Subject: []Subject{
+				{
+					Name: "curl-7.72.0.tar.bz2",
+					Digest: common.DigestSet{
+						"sha256": "ad91970864102a59765e20ce16216efc9d6ad381471f7accceceab7d905703ef",
+					},
+				},
+				{
+					Name: "curl-7.72.0.tar.gz",
+					Digest: common.DigestSet{
+						"sha256": "d4d5899a3868fbb6ae1856c3e55a32ce35913de3956d1973caccd37bd0174fa2",
+					},
+				},
+			},
+		},
+		Predicate: slsa01.ProvenancePredicate{
+			Builder: common.ProvenanceBuilder{
+				ID: "https://github.com/Attestations/GitHubHostedActions@v1",
+			},
+			Recipe: slsa01.ProvenanceRecipe{
+				Type:              "https://github.com/Attestations/GitHubActionsWorkflow@v1",
+				DefinedInMaterial: new(int),
+				EntryPoint:        "build.yaml:maketgz",
+			},
+			Metadata: &slsa01.ProvenanceMetadata{
+				BuildStartedOn: &testTime,
+				Completeness: slsa01.ProvenanceComplete{
+					Environment: true,
+				},
+			},
+			Materials: []common.ProvenanceMaterial{
+				{
+					URI: "git+https://github.com/curl/curl-docker@master",
+					Digest: common.DigestSet{
+						"sha1": "d6525c840a62b398424a78d792f457477135d0cf",
+					},
+				},
+				{
+					URI: "github_hosted_vm:ubuntu-18.04:20210123.1",
+				},
+			},
+		},
+	}
+	var got ProvenanceStatementSLSA01
+
+	if err := json.Unmarshal([]byte(data), &got); err != nil {
+		t.Errorf("failed to unmarshal json: %s\n", err)
+		return
+	}
+
+	// Make sure parsed time have same location set, location is only used
+	// for display purposes.
+	loc := want.Predicate.Metadata.BuildStartedOn.Location()
+	tmp := got.Predicate.Metadata.BuildStartedOn.In(loc)
+	got.Predicate.Metadata.BuildStartedOn = &tmp
+
+	assert.Equal(t, want, got, "Unexpexted object after decoding")
+}
+
+func TestEncodeProvenanceStatementSLSA01(t *testing.T) {
+	var testTime = time.Unix(1597826280, 0)
+	var p = ProvenanceStatementSLSA01{
+		StatementHeader: StatementHeader{
+			Type:          StatementInTotoV01,
+			PredicateType: slsa01.PredicateSLSAProvenance,
+			Subject: []Subject{
+				{
+					Name: "curl-7.72.0.tar.bz2",
+					Digest: common.DigestSet{
+						"sha256": "ad91970864102a59765e20ce16216efc9d6ad381471f7accceceab7d905703ef",
+					},
+				},
+				{
+					Name: "curl-7.72.0.tar.gz",
+					Digest: common.DigestSet{
+						"sha256": "d4d5899a3868fbb6ae1856c3e55a32ce35913de3956d1973caccd37bd0174fa2",
+					},
+				},
+			},
+		},
+		Predicate: slsa01.ProvenancePredicate{
+			Builder: common.ProvenanceBuilder{
+				ID: "https://github.com/Attestations/GitHubHostedActions@v1",
+			},
+			Recipe: slsa01.ProvenanceRecipe{
+				Type:              "https://github.com/Attestations/GitHubActionsWorkflow@v1",
+				DefinedInMaterial: new(int),
+				EntryPoint:        "build.yaml:maketgz",
+			},
+			Metadata: &slsa01.ProvenanceMetadata{
+				BuildStartedOn:  &testTime,
+				BuildFinishedOn: &testTime,
+				Completeness: slsa01.ProvenanceComplete{
+					Arguments:   true,
+					Environment: false,
+					Materials:   true,
+				},
+			},
+			Materials: []common.ProvenanceMaterial{
+				{
+					URI: "git+https://github.com/curl/curl-docker@master",
+					Digest: common.DigestSet{
+						"sha1": "d6525c840a62b398424a78d792f457477135d0cf",
+					},
+				},
+				{
+					URI: "github_hosted_vm:ubuntu-18.04:20210123.1",
+				},
+				{
+					URI: "git+https://github.com/curl/",
+				},
+			},
+		},
+	}
+	var want = `{"_type":"https://in-toto.io/Statement/v0.1","predicateType":"https://slsa.dev/provenance/v0.1","subject":[{"name":"curl-7.72.0.tar.bz2","digest":{"sha256":"ad91970864102a59765e20ce16216efc9d6ad381471f7accceceab7d905703ef"}},{"name":"curl-7.72.0.tar.gz","digest":{"sha256":"d4d5899a3868fbb6ae1856c3e55a32ce35913de3956d1973caccd37bd0174fa2"}}],"predicate":{"builder":{"id":"https://github.com/Attestations/GitHubHostedActions@v1"},"recipe":{"type":"https://github.com/Attestations/GitHubActionsWorkflow@v1","definedInMaterial":0,"entryPoint":"build.yaml:maketgz"},"metadata":{"buildStartedOn":"2020-08-19T08:38:00Z","buildFinishedOn":"2020-08-19T08:38:00Z","completeness":{"arguments":true,"environment":false,"materials":true},"reproducible":false},"materials":[{"uri":"git+https://github.com/curl/curl-docker@master","digest":{"sha1":"d6525c840a62b398424a78d792f457477135d0cf"}},{"uri":"github_hosted_vm:ubuntu-18.04:20210123.1"},{"uri":"git+https://github.com/curl/"}]}}`
+
+	b, err := json.Marshal(&p)
+	assert.Nil(t, err, "Error during JSON marshal")
+	assert.Equal(t, want, string(b), "Wrong JSON produced")
+}
+
 // Test that the default date (January 1, year 1, 00:00:00 UTC) is
 // not marshalled
 func TestMetadataNoTime(t *testing.T) {
-	var md = slsa.ProvenanceMetadata{
-		Completeness: slsa.ProvenanceComplete{
+	var md = slsa02.ProvenanceMetadata{
+		Completeness: slsa02.ProvenanceComplete{
 			Parameters: true,
 		},
 		Reproducible: true,
 	}
 	var want = `{"completeness":{"parameters":true,"environment":false,"materials":false},"reproducible":true}`
-	var got slsa.ProvenanceMetadata
+	var got slsa02.ProvenanceMetadata
 	b, err := json.Marshal(&md)
 
 	t.Run("Marshal", func(t *testing.T) {
@@ -1717,6 +1883,45 @@ func TestMetadataNoTime(t *testing.T) {
 		err := json.Unmarshal(b, &got)
 		assert.Nil(t, err, "Error during JSON unmarshal")
 		assert.Equal(t, md, got, "Wrong struct after JSON unmarshal")
+	})
+}
+
+// Verify that the behaviour of definedInMaterial can be controlled,
+// as there is a semantic difference in value present or 0.
+func TestRecipe(t *testing.T) {
+	var r = slsa01.ProvenanceRecipe{
+		Type:       "testType",
+		EntryPoint: "testEntry",
+	}
+	var want = `{"type":"testType","entryPoint":"testEntry"}`
+	var got slsa01.ProvenanceRecipe
+	b, err := json.Marshal(&r)
+
+	t.Run("No time/marshal", func(t *testing.T) {
+		assert.Nil(t, err, "Error during JSON marshal")
+		assert.Equal(t, want, string(b), "Wrong JSON produced")
+	})
+
+	t.Run("No time/unmarshal", func(t *testing.T) {
+		err = json.Unmarshal(b, &got)
+		assert.Nil(t, err, "Error during JSON unmarshal")
+		assert.Equal(t, r, got, "Wrong struct after JSON unmarshal")
+	})
+
+	// Set time to zero and run test again
+	r.DefinedInMaterial = new(int)
+	want = `{"type":"testType","definedInMaterial":0,"entryPoint":"testEntry"}`
+	b, err = json.Marshal(&r)
+
+	t.Run("With time/marshal", func(t *testing.T) {
+		assert.Nil(t, err, "Error during JSON marshal")
+		assert.Equal(t, want, string(b), "Wrong JSON produced")
+	})
+
+	t.Run("With time/unmarshal", func(t *testing.T) {
+		err = json.Unmarshal(b, &got)
+		assert.Nil(t, err, "Error during JSON unmarshal")
+		assert.Equal(t, r, got, "Wrong struct after JSON unmarshal")
 	})
 }
 
@@ -1754,7 +1959,7 @@ func TestLinkStatement(t *testing.T) {
 			Subject: []Subject{
 				{
 					Name: "baz",
-					Digest: slsa.DigestSet{
+					Digest: common.DigestSet{
 						"sha256": "hash1",
 					},
 				},

--- a/in_toto/slsa_provenance/common/common.go
+++ b/in_toto/slsa_provenance/common/common.go
@@ -1,0 +1,16 @@
+package common
+
+// DigestSet contains a set of digests. It is represented as a map from
+// algorithm name to lowercase hex-encoded value.
+type DigestSet map[string]string
+
+// ProvenanceBuilder idenfifies the entity that executed the build steps.
+type ProvenanceBuilder struct {
+	ID string `json:"id"`
+}
+
+// ProvenanceMaterial defines the materials used to build an artifact.
+type ProvenanceMaterial struct {
+	URI    string    `json:"uri,omitempty"`
+	Digest DigestSet `json:"digest,omitempty"`
+}

--- a/in_toto/slsa_provenance/v0.1/provenance.go
+++ b/in_toto/slsa_provenance/v0.1/provenance.go
@@ -1,6 +1,10 @@
 package v01
 
-import "time"
+import (
+	"time"
+
+	"github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
+)
 
 const (
 	// PredicateSLSAProvenance represents a build provenance for an artifact.
@@ -9,15 +13,10 @@ const (
 
 // ProvenancePredicate is the provenance predicate definition.
 type ProvenancePredicate struct {
-	Builder   ProvenanceBuilder    `json:"builder"`
-	Recipe    ProvenanceRecipe     `json:"recipe"`
-	Metadata  *ProvenanceMetadata  `json:"metadata,omitempty"`
-	Materials []ProvenanceMaterial `json:"materials,omitempty"`
-}
-
-// ProvenanceBuilder idenfifies the entity that executed the build steps.
-type ProvenanceBuilder struct {
-	ID string `json:"id"`
+	Builder   common.ProvenanceBuilder    `json:"builder"`
+	Recipe    ProvenanceRecipe            `json:"recipe"`
+	Metadata  *ProvenanceMetadata         `json:"metadata,omitempty"`
+	Materials []common.ProvenanceMaterial `json:"materials,omitempty"`
 }
 
 // ProvenanceRecipe describes the actions performed by the builder.
@@ -41,12 +40,6 @@ type ProvenanceMetadata struct {
 	Reproducible    bool               `json:"reproducible"`
 }
 
-// ProvenanceMaterial defines the materials used to build an artifact.
-type ProvenanceMaterial struct {
-	URI    string    `json:"uri"`
-	Digest DigestSet `json:"digest,omitempty"`
-}
-
 // ProvenanceComplete indicates wheter the claims in build/recipe are complete.
 // For in depth information refer to the specifictaion:
 // https://github.com/in-toto/attestation/blob/v0.1.0/spec/predicates/provenance.md
@@ -55,7 +48,3 @@ type ProvenanceComplete struct {
 	Environment bool `json:"environment"`
 	Materials   bool `json:"materials"`
 }
-
-// DigestSet contains a set of digests. It is represented as a map from
-// algorithm name to lowercase hex-encoded value.
-type DigestSet map[string]string

--- a/in_toto/slsa_provenance/v0.1/provenance_test.go
+++ b/in_toto/slsa_provenance/v0.1/provenance_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -38,7 +39,7 @@ func TestDecodeProvenancePredicate(t *testing.T) {
 `
 	var testTime = time.Unix(1597826280, 0)
 	var want = ProvenancePredicate{
-		Builder: ProvenanceBuilder{
+		Builder: common.ProvenanceBuilder{
 			ID: "https://github.com/Attestations/GitHubHostedActions@v1",
 		},
 		Recipe: ProvenanceRecipe{
@@ -52,10 +53,10 @@ func TestDecodeProvenancePredicate(t *testing.T) {
 				Environment: true,
 			},
 		},
-		Materials: []ProvenanceMaterial{
+		Materials: []common.ProvenanceMaterial{
 			{
 				URI: "git+https://github.com/curl/curl-docker@master",
-				Digest: DigestSet{
+				Digest: common.DigestSet{
 					"sha1": "d6525c840a62b398424a78d792f457477135d0cf",
 				},
 			},
@@ -83,7 +84,7 @@ func TestDecodeProvenancePredicate(t *testing.T) {
 func TestEncodeProvenancePredicate(t *testing.T) {
 	var testTime = time.Unix(1597826280, 0).In(time.UTC)
 	var p = ProvenancePredicate{
-		Builder: ProvenanceBuilder{
+		Builder: common.ProvenanceBuilder{
 			ID: "https://github.com/Attestations/GitHubHostedActions@v1",
 		},
 		Recipe: ProvenanceRecipe{
@@ -100,10 +101,10 @@ func TestEncodeProvenancePredicate(t *testing.T) {
 				Materials:   true,
 			},
 		},
-		Materials: []ProvenanceMaterial{
+		Materials: []common.ProvenanceMaterial{
 			{
 				URI: "git+https://github.com/curl/curl-docker@master",
-				Digest: DigestSet{
+				Digest: common.DigestSet{
 					"sha1": "d6525c840a62b398424a78d792f457477135d0cf",
 				},
 			},

--- a/in_toto/slsa_provenance/v0.2/provenance.go
+++ b/in_toto/slsa_provenance/v0.2/provenance.go
@@ -1,6 +1,10 @@
 package v02
 
-import "time"
+import (
+	"time"
+
+	"github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
+)
 
 const (
 	// PredicateSLSAProvenance represents a build provenance for an artifact.
@@ -9,17 +13,12 @@ const (
 
 // ProvenancePredicate is the provenance predicate definition.
 type ProvenancePredicate struct {
-	Builder     ProvenanceBuilder    `json:"builder"`
-	BuildType   string               `json:"buildType"`
-	Invocation  ProvenanceInvocation `json:"invocation,omitempty"`
-	BuildConfig interface{}          `json:"buildConfig,omitempty"`
-	Metadata    *ProvenanceMetadata  `json:"metadata,omitempty"`
-	Materials   []ProvenanceMaterial `json:"materials,omitempty"`
-}
-
-// ProvenanceBuilder idenfifies the entity that executed the build steps.
-type ProvenanceBuilder struct {
-	ID string `json:"id"`
+	Builder     common.ProvenanceBuilder    `json:"builder"`
+	BuildType   string                      `json:"buildType"`
+	Invocation  ProvenanceInvocation        `json:"invocation,omitempty"`
+	BuildConfig interface{}                 `json:"buildConfig,omitempty"`
+	Metadata    *ProvenanceMetadata         `json:"metadata,omitempty"`
+	Materials   []common.ProvenanceMaterial `json:"materials,omitempty"`
 }
 
 // ProvenanceInvocation identifies the event that kicked off the build.
@@ -30,9 +29,9 @@ type ProvenanceInvocation struct {
 }
 
 type ConfigSource struct {
-	URI        string    `json:"uri,omitempty"`
-	Digest     DigestSet `json:"digest,omitempty"`
-	EntryPoint string    `json:"entryPoint,omitempty"`
+	URI        string           `json:"uri,omitempty"`
+	Digest     common.DigestSet `json:"digest,omitempty"`
+	EntryPoint string           `json:"entryPoint,omitempty"`
 }
 
 // ProvenanceMetadata contains metadata for the built artifact.
@@ -46,12 +45,6 @@ type ProvenanceMetadata struct {
 	Reproducible    bool               `json:"reproducible"`
 }
 
-// ProvenanceMaterial defines the materials used to build an artifact.
-type ProvenanceMaterial struct {
-	URI    string    `json:"uri,omitempty"`
-	Digest DigestSet `json:"digest,omitempty"`
-}
-
 // ProvenanceComplete indicates wheter the claims in build/recipe are complete.
 // For in depth information refer to the specifictaion:
 // https://github.com/in-toto/attestation/blob/v0.1.0/spec/predicates/provenance.md
@@ -60,7 +53,3 @@ type ProvenanceComplete struct {
 	Environment bool `json:"environment"`
 	Materials   bool `json:"materials"`
 }
-
-// DigestSet contains a set of digests. It is represented as a map from
-// algorithm name to lowercase hex-encoded value.
-type DigestSet map[string]string

--- a/in_toto/slsa_provenance/v0.2/provenance_test.go
+++ b/in_toto/slsa_provenance/v0.2/provenance_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -19,7 +20,7 @@ func TestDecodeProvenancePredicate(t *testing.T) {
     "invocation": {
       "configSource": {
 		"uri": "git+https://github.com/curl/curl-docker@master",
-        "digest": { "sha1": "d6525c840a62b398424a78d792f457477135d0cf" },   
+        "digest": { "sha1": "d6525c840a62b398424a78d792f457477135d0cf" },
 		"entryPoint": "build.yaml:maketgz"
 	  }
     },
@@ -41,14 +42,14 @@ func TestDecodeProvenancePredicate(t *testing.T) {
 `
 	var testTime = time.Unix(1597826280, 0)
 	var want = ProvenancePredicate{
-		Builder: ProvenanceBuilder{
+		Builder: common.ProvenanceBuilder{
 			ID: "https://github.com/Attestations/GitHubHostedActions@v1",
 		},
 		BuildType: "https://github.com/Attestations/GitHubActionsWorkflow@v1",
 		Invocation: ProvenanceInvocation{
 			ConfigSource: ConfigSource{
 				URI: "git+https://github.com/curl/curl-docker@master",
-				Digest: DigestSet{
+				Digest: common.DigestSet{
 					"sha1": "d6525c840a62b398424a78d792f457477135d0cf",
 				},
 				EntryPoint: "build.yaml:maketgz",
@@ -60,10 +61,10 @@ func TestDecodeProvenancePredicate(t *testing.T) {
 				Environment: true,
 			},
 		},
-		Materials: []ProvenanceMaterial{
+		Materials: []common.ProvenanceMaterial{
 			{
 				URI: "git+https://github.com/curl/curl-docker@master",
-				Digest: DigestSet{
+				Digest: common.DigestSet{
 					"sha1": "d6525c840a62b398424a78d792f457477135d0cf",
 				},
 			},
@@ -90,7 +91,7 @@ func TestDecodeProvenancePredicate(t *testing.T) {
 func TestEncodeProvenancePredicate(t *testing.T) {
 	var testTime = time.Unix(1597826280, 0).In(time.UTC)
 	var p = ProvenancePredicate{
-		Builder: ProvenanceBuilder{
+		Builder: common.ProvenanceBuilder{
 			ID: "https://github.com/Attestations/GitHubHostedActions@v1",
 		},
 		BuildType: "https://github.com/Attestations/GitHubActionsWorkflow@v1",
@@ -98,7 +99,7 @@ func TestEncodeProvenancePredicate(t *testing.T) {
 			ConfigSource: ConfigSource{
 				EntryPoint: "build.yaml:maketgz",
 				URI:        "git+https://github.com/curl/curl-docker@master",
-				Digest: DigestSet{
+				Digest: common.DigestSet{
 					"sha1": "d6525c840a62b398424a78d792f457477135d0cf",
 				},
 			},
@@ -113,10 +114,10 @@ func TestEncodeProvenancePredicate(t *testing.T) {
 				Materials:   true,
 			},
 		},
-		Materials: []ProvenanceMaterial{
+		Materials: []common.ProvenanceMaterial{
 			{
 				URI: "git+https://github.com/curl/curl-docker@master",
-				Digest: DigestSet{
+				Digest: common.DigestSet{
 					"sha1": "d6525c840a62b398424a78d792f457477135d0cf",
 				},
 			},


### PR DESCRIPTION
**Description:**
As per https://github.com/in-toto/in-toto-golang/issues/176, we want to
maintain multiple versions of slsa-specific statement struct especially
when slsa v1 comes out in next couple of months. Reverting slsa0.1 back
helps the community evaluate the work.

Summary:
- Version specific statement structs are added (`ProvenanceStatementSLSA01`
and `ProvenanceStatementSLSA02`).
- The old `ProvenanceStatement` struct specific to slsa 0.2 is
still available, but will be officially deprecated in favour of
version explicit alternatives.
- Some common types shared between 0.1 and 0.2 are moved to the newly added
`common` package including `DigestSet`, `ProvenanceBuilder` and `ProvenanceMaterial`.
This might be a breaking change for the downstream users who use those
types to construct a statement.


If you have any questions/comments, please feel free to comment on this issue.




**Please verify and check that the pull request fulfills the following
requirements:**

- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


