### PR TITLE
Update Go versions used in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.16.x, 1.17.x]
+        go-version: [1.18.x, 1.19.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -14,9 +14,6 @@ jobs:
         go-version: ${{ matrix.go-version }}
     - name: Checkout code
       uses: actions/checkout@v3
-    - name: Format Unix
-      if: runner.os == 'Linux'
-      run: test -z $(go fmt ./...)
     - name: Test
       run: go test -covermode atomic -coverprofile='profile.cov' ./...
     - name: Send coverage

--- a/.github/workflows/verify-docgen-fmt.yml
+++ b/.github/workflows/verify-docgen-fmt.yml
@@ -1,4 +1,4 @@
-name: Docgen
+name: Docgen and go fmt
 
 on:
   workflow_dispatch:
@@ -15,5 +15,15 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.17.x'
+          go-version: '1.19.x'
       - run: ./scripts/verify-docs.sh
+  fmt:
+    name: Verify go fmt
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '1.19.x'
+      - run: test -z $(go fmt ./...)

--- a/in_toto/keylib.go
+++ b/in_toto/keylib.go
@@ -197,9 +197,9 @@ func (k *Key) setKeyComponents(pubKeyBytes []byte, privateKeyBytes []byte, keyTy
 parseKey tries to parse a PEM []byte slice. Using the following standards
 in the given order:
 
-	* PKCS8
-	* PKCS1
-	* PKIX
+  - PKCS8
+  - PKCS1
+  - PKIX
 
 On success it returns the parsed key and nil.
 On failure it returns nil and the error ErrFailedPEMParsing
@@ -260,22 +260,22 @@ LoadKey loads the key file at specified file path into the key object.
 It automatically derives the PEM type and the key type.
 Right now the following PEM types are supported:
 
-	* PKCS1 for private keys
-	* PKCS8	for private keys
-	* PKIX for public keys
+  - PKCS1 for private keys
+  - PKCS8	for private keys
+  - PKIX for public keys
 
 The following key types are supported and will be automatically assigned to
 the key type field:
 
-	* ed25519
-	* rsa
-	* ecdsa
+  - ed25519
+  - rsa
+  - ecdsa
 
 The following schemes are supported:
 
-	* ed25519 -> ed25519
-	* rsa -> rsassa-pss-sha256
-	* ecdsa -> ecdsa-sha256-nistp256
+  - ed25519 -> ed25519
+  - rsa -> rsassa-pss-sha256
+  - ecdsa -> ecdsa-sha256-nistp256
 
 Note that, this behavior is consistent with the securesystemslib, except for
 ecdsa. We do not use the scheme string as key type in in-toto-golang.
@@ -283,11 +283,11 @@ Instead we are going with a ecdsa/ecdsa-sha2-nistp256 pair.
 
 On success it will return nil. The following errors can happen:
 
-	* path not found or not readable
-	* no PEM block in the loaded file
-	* no valid PKCS8/PKCS1 private key or PKIX public key
-	* errors while marshalling
-	* unsupported key types
+  - path not found or not readable
+  - no PEM block in the loaded file
+  - no valid PKCS8/PKCS1 private key or PKIX public key
+  - errors while marshalling
+  - unsupported key types
 */
 func (k *Key) LoadKey(path string, scheme string, KeyIDHashAlgorithms []string) error {
 	pemFile, err := os.Open(path)
@@ -450,8 +450,8 @@ with the provided key. If everything goes right GenerateSignature will return
 a for the key valid signature and err=nil. If something goes wrong it will
 return a not initialized signature and an error. Possible errors are:
 
-	* ErrNoPEMBlock
-	* ErrUnsupportedKeyType
+  - ErrNoPEMBlock
+  - ErrUnsupportedKeyType
 
 Currently supported is only one scheme per key.
 
@@ -554,9 +554,9 @@ func GenerateSignature(signable []byte, key Key) (Signature, error) {
 VerifySignature will verify unverified byte data via a passed key and signature.
 Supported key types are:
 
-	* rsa
-	* ed25519
-	* ecdsa
+  - rsa
+  - ed25519
+  - ecdsa
 
 When encountering an RSA key, VerifySignature will decode the PEM block in the key
 and will call rsa.VerifyPSS() for verifying the RSA signature.
@@ -655,7 +655,8 @@ func VerifySignature(key Key, sig Signature, unverified []byte) error {
 /*
 VerifyCertificateTrust verifies that the certificate has a chain of trust
 to a root in rootCertPool, possibly using any intermediates in
-intermediateCertPool */
+intermediateCertPool
+*/
 func VerifyCertificateTrust(cert *x509.Certificate, rootCertPool, intermediateCertPool *x509.CertPool) ([][]*x509.Certificate, error) {
 	verifyOptions := x509.VerifyOptions{
 		Roots:         rootCertPool,

--- a/in_toto/keylib_test.go
+++ b/in_toto/keylib_test.go
@@ -130,9 +130,9 @@ func TestValidSignatures(t *testing.T) {
 
 // TestLoadKeyErrors tests the LoadKey functions for the most popular errors:
 //
-//	* os.ErrNotExist (triggered, when the file does not exist)
-//	* ErrNoPEMBlock (for example if the passed file is not a PEM block)
-//  * ErrFailedPEMParsing (for example if we pass an EC key, instead a key in PKCS8 format)
+//   - os.ErrNotExist (triggered, when the file does not exist)
+//   - ErrNoPEMBlock (for example if the passed file is not a PEM block)
+//   - ErrFailedPEMParsing (for example if we pass an EC key, instead a key in PKCS8 format)
 func TestLoadKeyErrors(t *testing.T) {
 	invalidTables := []struct {
 		name           string
@@ -163,9 +163,9 @@ func TestLoadKeyErrors(t *testing.T) {
 
 // TestLoadKeyDefaultsErrors tests the LoadKeyDefaults functions for the most popular errors:
 //
-//	* os.ErrNotExist (triggered, when the file does not exist)
-//	* ErrNoPEMBlock (for example if the passed file is not a PEM block)
-//  * ErrFailedPEMParsing (for example if we pass an EC key, instead a key in PKCS8 format)
+//   - os.ErrNotExist (triggered, when the file does not exist)
+//   - ErrNoPEMBlock (for example if the passed file is not a PEM block)
+//   - ErrFailedPEMParsing (for example if we pass an EC key, instead a key in PKCS8 format)
 func TestLoadKeyDefaultsErrors(t *testing.T) {
 	invalidTables := []struct {
 		name string

--- a/in_toto/match.go
+++ b/in_toto/match.go
@@ -35,7 +35,6 @@ var errBadPattern = errors.New("syntax error in pattern")
 // Match requires pattern to match all of name, not just a substring.
 // The only possible returned error is ErrBadPattern, when pattern
 // is malformed.
-//
 func match(pattern, name string) (matched bool, err error) {
 Pattern:
 	for len(pattern) > 0 {

--- a/in_toto/model.go
+++ b/in_toto/model.go
@@ -414,6 +414,7 @@ func validateLink(link Link) error {
 LinkNameFormat represents a format string used to create the filename for a
 signed Link (wrapped in a Metablock). It consists of the name of the link and
 the first 8 characters of the signing key id. E.g.:
+
 	fmt.Sprintf(LinkNameFormat, "package",
 	"2f89b9272acfc8f4a0a0f094d789fdb0ba798b0fe41f2f5f417c12f0085ff498")
 	// returns "package.2f89b9272.link"
@@ -423,6 +424,7 @@ const PreliminaryLinkNameFormat = ".%s.%.8s.link-unfinished"
 
 /*
 LinkNameFormatShort is for links that are not signed, e.g.:
+
 	fmt.Sprintf(LinkNameFormatShort, "unsigned")
 	// returns "unsigned.link"
 */


### PR DESCRIPTION
Switch from testing Go `1.16.x`, `1.17.x` to `1.17.x`, `1.18.x`, `1.19.x`.