### PR TITLE
fix: fix one more parameter spelling in SLSA v1.0 provenance

### DIFF
--- a/in_toto/slsa_provenance/v1.0/provenance.go
+++ b/in_toto/slsa_provenance/v1.0/provenance.go
@@ -46,7 +46,7 @@ type ProvenanceBuildDefinition struct {
 	// verification. Consumers SHOULD have an expectation of what “good” looks
 	// like; the more information that they need to check, the harder that task
 	// becomes.
-	ExternalParameters interface{} `json:"externalParamaters"`
+	ExternalParameters interface{} `json:"externalParameters"`
 
 	// The parameters that are under the control of the builder. The primary
 	// intention of this field is for debugging, incident response, and

--- a/in_toto/slsa_provenance/v1.0/provenance_test.go
+++ b/in_toto/slsa_provenance/v1.0/provenance_test.go
@@ -112,7 +112,7 @@ func TestEncodeProvenancePredicate(t *testing.T) {
 			},
 		},
 	}
-	var want = `{"buildDefinition":{"buildType":"https://github.com/Attestations/GitHubActionsWorkflow@v1","externalParamaters":{"entryPoint":"build.yaml:maketgz","source":"git+https://github.com/curl/curl-docker@master"},"systemParameters":{"GITHUB_RUNNER":"github_hosted_vm:ubuntu-18.04:20210123.1"},"resolvedDependencies":[{"uri":"git+https://github.com/curl/curl-docker@master","digest":{"sha1":"d6525c840a62b398424a78d792f457477135d0cf"}},{"uri":"github_hosted_vm:ubuntu-18.04:20210123.1"},{"uri":"git+https://github.com/curl/"}]},"runDetails":{"builder":{"id":"https://github.com/Attestations/GitHubHostedActions@v1"},"metadata":{"startedOn":"2020-08-19T08:38:00Z","finishedOn":"2020-08-19T08:38:00Z"}}}`
+	var want = `{"buildDefinition":{"buildType":"https://github.com/Attestations/GitHubActionsWorkflow@v1","externalParameters":{"entryPoint":"build.yaml:maketgz","source":"git+https://github.com/curl/curl-docker@master"},"systemParameters":{"GITHUB_RUNNER":"github_hosted_vm:ubuntu-18.04:20210123.1"},"resolvedDependencies":[{"uri":"git+https://github.com/curl/curl-docker@master","digest":{"sha1":"d6525c840a62b398424a78d792f457477135d0cf"}},{"uri":"github_hosted_vm:ubuntu-18.04:20210123.1"},{"uri":"git+https://github.com/curl/"}]},"runDetails":{"builder":{"id":"https://github.com/Attestations/GitHubHostedActions@v1"},"metadata":{"startedOn":"2020-08-19T08:38:00Z","finishedOn":"2020-08-19T08:38:00Z"}}}`
 	b, err := json.Marshal(&p)
 	assert.Nil(t, err, "Error during JSON marshal")
 	if d := cmp.Diff(want, string(b)); d != "" {


### PR DESCRIPTION
**Fixes issue:**
Fixes the marshalling spelling of parameter.

**Description:**

I'm so sorry! I thought this commit got pushed to the previous PR but I left it dangling locally.


**Please verify and check that the pull request fulfills the following
requirements:**

- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


