### PR TITLE
Handle ctx for go-sslib

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/google/go-cmp v0.5.9
-	github.com/secure-systems-lab/go-securesystemslib v0.4.0
+	github.com/secure-systems-lab/go-securesystemslib v0.5.0
 	github.com/shibumi/go-pathspec v1.3.0
 	github.com/spf13/cobra v1.6.1
 	github.com/spiffe/go-spiffe/v2 v2.1.2

--- a/go.sum
+++ b/go.sum
@@ -562,6 +562,8 @@ github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/secure-systems-lab/go-securesystemslib v0.4.0 h1:b23VGrQhTA8cN2CbBw7/FulN9fTtqYUdS5+Oxzt+DUE=
 github.com/secure-systems-lab/go-securesystemslib v0.4.0/go.mod h1:FGBZgq2tXWICsxWQW1msNf49F0Pf2Op5Htayx335Qbs=
+github.com/secure-systems-lab/go-securesystemslib v0.5.0 h1:oTiNu0QnulMQgN/hLK124wJD/r2f9ZhIUuKIeBsCBT8=
+github.com/secure-systems-lab/go-securesystemslib v0.5.0/go.mod h1:uoCqUC0Ap7jrBSEanxT+SdACYJTVplRXWLkGMuDjXqk=
 github.com/shibumi/go-pathspec v1.3.0 h1:QUyMZhFo0Md5B8zV8x2tesohbb5kfbpTi9rBnKh5dkI=
 github.com/shibumi/go-pathspec v1.3.0/go.mod h1:Xutfslp817l2I1cZvgcfeMQJG5QnU2lh5tVaaMCl3jE=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=

--- a/in_toto/model.go
+++ b/in_toto/model.go
@@ -1,6 +1,7 @@
 package in_toto
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/rsa"
 	"crypto/x509"
@@ -1059,15 +1060,15 @@ func NewDSSESigner(p ...dsse.SignVerifier) (*DSSESigner, error) {
 	}, nil
 }
 
-func (s *DSSESigner) SignPayload(body []byte) (*dsse.Envelope, error) {
-	return s.signer.SignPayload(PayloadType, body)
+func (s *DSSESigner) SignPayload(ctx context.Context, body []byte) (*dsse.Envelope, error) {
+	return s.signer.SignPayload(ctx, PayloadType, body)
 }
 
-func (s *DSSESigner) Verify(e *dsse.Envelope) error {
+func (s *DSSESigner) Verify(ctx context.Context, e *dsse.Envelope) error {
 	if e.PayloadType != PayloadType {
 		return ErrInvalidPayloadType
 	}
 
-	_, err := s.signer.Verify(e)
+	_, err := s.signer.Verify(ctx, e)
 	return err
 }


### PR DESCRIPTION
**Fixes issue:** N/A

**Description:**

This updates in-toto-golang to support passing in context when using DSSE APIs (see: https://github.com/secure-systems-lab/go-securesystemslib/pull/34).

**Please verify and check that the pull request fulfills the following
requirements:**

- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


