### PR TITLE
Add type aliases to v0.2 provenance to revert backwards incompatible change.

### DIFF
--- a/in_toto/slsa_provenance/v0.2/provenance.go
+++ b/in_toto/slsa_provenance/v0.2/provenance.go
@@ -11,6 +11,13 @@ const (
 	PredicateSLSAProvenance = "https://slsa.dev/provenance/v0.2"
 )
 
+// These are type aliases to common to avoid backwards incompatible changes.
+type (
+	DigestSet          = common.DigestSet
+	ProvenanceBuilder  = common.ProvenanceBuilder
+	ProvenanceMaterial = common.ProvenanceMaterial
+)
+
 // ProvenancePredicate is the provenance predicate definition.
 type ProvenancePredicate struct {
 	// Builder identifies the entity that executed the invocation, which is trusted to have


### PR DESCRIPTION
Tripped over a few upgrade issues in sigstore + tekton projects:

```
undefined: v0.2.DigestSet
```

This adds a type alias to the v0.2 package to point to the common package to let things pass.

**Fixes issue:**


**Description:**


**Please verify and check that the pull request fulfills the following
requirements:**

- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

cc @chuangw6 
