### PR TITLE
Fix typo in struct name

### DIFF
--- a/in_toto/slsa_provenance/v1.0/provenance.go
+++ b/in_toto/slsa_provenance/v1.0/provenance.go
@@ -21,7 +21,7 @@ type ProvenancePredicate struct {
 	BuildDefinition ProvenanceBuildDefinition `json:"buildDefinition"`
 
 	// Details specific to this particular execution of the build.
-	RunDetails ProvenanaceRunDetails `json:"runDetails"`
+	RunDetails ProvenanceRunDetails `json:"runDetails"`
 }
 
 // ProvenanceBuildDefinition describes the inputs to the build.
@@ -66,7 +66,7 @@ type ProvenanceBuildDefinition struct {
 
 // ProvenanceRunDetails includes details specific to a particular execution of a
 // build.
-type ProvenanaceRunDetails struct {
+type ProvenanceRunDetails struct {
 	// Identifies the entity that executed the invocation, which is trusted to
 	// have correctly performed the operation and populated this provenance.
 	//

--- a/in_toto/slsa_provenance/v1.0/provenance_test.go
+++ b/in_toto/slsa_provenance/v1.0/provenance_test.go
@@ -51,7 +51,7 @@ func TestDecodeProvenancePredicate(t *testing.T) {
 				},
 			},
 		},
-		RunDetails: ProvenanaceRunDetails{
+		RunDetails: ProvenanceRunDetails{
 			Builder: Builder{
 				ID: "https://github.com/Attestations/GitHubHostedActions@v1",
 			},
@@ -102,7 +102,7 @@ func TestEncodeProvenancePredicate(t *testing.T) {
 				},
 			},
 		},
-		RunDetails: ProvenanaceRunDetails{
+		RunDetails: ProvenanceRunDetails{
 			Builder: Builder{
 				ID: "https://github.com/Attestations/GitHubHostedActions@v1",
 			},


### PR DESCRIPTION
**Fixes issue:** #225 


**Description:**

Fixes a typo in the word Provenance.

**Please verify and check that the pull request fulfills the following
requirements:**

- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


