### PR TITLE
Replace uses of deprecated ioutil

### DIFF
--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	intoto "github.com/in-toto/in-toto-golang/in_toto"
@@ -102,22 +101,12 @@ func verify(cmd *cobra.Command, args []string) error {
 
 	intermediatePems := make([][]byte, 0, len(intermediatePaths))
 	for _, intermediate := range intermediatePaths {
-		f, err := os.Open(intermediate)
-		if err != nil {
-			return fmt.Errorf("failed to open intermediate %s: %w", intermediate, err)
-		}
-		defer f.Close()
-
-		pemBytes, err := ioutil.ReadAll(f)
+		pemBytes, err := os.ReadFile(intermediate)
 		if err != nil {
 			return fmt.Errorf("failed to read intermediate %s: %w", intermediate, err)
 		}
 
 		intermediatePems = append(intermediatePems, pemBytes)
-
-		if err := f.Close(); err != nil {
-			return fmt.Errorf("could not close intermediate cert: %w", err)
-		}
 	}
 
 	_, err := intoto.InTotoVerify(layoutMb, layoutKeys, linkDir, "", make(map[string]string), intermediatePems, lineNormalization)

--- a/in_toto/in_toto_test.go
+++ b/in_toto/in_toto_test.go
@@ -2,7 +2,6 @@ package in_toto
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -14,7 +13,7 @@ const testData = "../test/data"
 // This can be used for test setup and teardown, e.g. copy test data to a tmp
 // test dir, change to that dir and remove the and contents in the end
 func TestMain(m *testing.M) {
-	testDir, err := ioutil.TempDir("", "in_toto_test_dir")
+	testDir, err := os.MkdirTemp("", "in_toto_test_dir")
 	if err != nil {
 		panic("Cannot create temp test dir")
 	}
@@ -23,12 +22,12 @@ func TestMain(m *testing.M) {
 	// NOTE: Only works for a flat directory of files
 	testFiles, _ := filepath.Glob(filepath.Join(testData, "*"))
 	for _, inputPath := range testFiles {
-		input, err := ioutil.ReadFile(inputPath)
+		input, err := os.ReadFile(inputPath)
 		if err != nil {
 			panic(fmt.Sprintf("Cannot copy test files (read error: %s)", err))
 		}
 		outputPath := filepath.Join(testDir, filepath.Base(inputPath))
-		err = ioutil.WriteFile(outputPath, input, 0644)
+		err = os.WriteFile(outputPath, input, 0644)
 		if err != nil {
 			panic(fmt.Sprintf("Cannot copy test files (write error: %s)", err))
 		}

--- a/in_toto/keylib.go
+++ b/in_toto/keylib.go
@@ -13,7 +13,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -325,7 +324,7 @@ func (k *Key) LoadKeyReader(r io.Reader, scheme string, KeyIDHashAlgorithms []st
 		return ErrNoPEMBlock
 	}
 	// Read key bytes
-	pemBytes, err := ioutil.ReadAll(r)
+	pemBytes, err := io.ReadAll(r)
 	if err != nil {
 		return err
 	}
@@ -344,7 +343,7 @@ func (k *Key) LoadKeyReaderDefaults(r io.Reader) error {
 		return ErrNoPEMBlock
 	}
 	// Read key bytes
-	pemBytes, err := ioutil.ReadAll(r)
+	pemBytes, err := io.ReadAll(r)
 	if err != nil {
 		return err
 	}

--- a/in_toto/model.go
+++ b/in_toto/model.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"regexp"
@@ -771,15 +770,8 @@ object on which it was called.  It returns an error if it cannot parse
 a valid JSON formatted Metablock that contains a Link or Layout.
 */
 func (mb *Metablock) Load(path string) error {
-	// Open file and close before returning
-	jsonFile, err := os.Open(path)
-	if err != nil {
-		return err
-	}
-	defer jsonFile.Close()
-
 	// Read entire file
-	jsonBytes, err := ioutil.ReadAll(jsonFile)
+	jsonBytes, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}
@@ -852,7 +844,7 @@ func (mb *Metablock) Load(path string) error {
 			" metadata must be one of 'link' or 'layout'")
 	}
 
-	return jsonFile.Close()
+	return nil
 }
 
 /*
@@ -868,7 +860,7 @@ func (mb *Metablock) Dump(path string) error {
 	}
 
 	// Write JSON bytes to the passed path with permissions (-rw-r--r--)
-	err = ioutil.WriteFile(path, jsonBytes, 0644)
+	err = os.WriteFile(path, jsonBytes, 0644)
 	if err != nil {
 		return err
 	}

--- a/in_toto/model_test.go
+++ b/in_toto/model_test.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"strings"
@@ -135,7 +134,7 @@ func TestMetablockLoad(t *testing.T) {
 
 	for i := 0; i < len(invalidJSONBytes); i++ {
 		fn := fmt.Sprintf("invalid-metadata-%v.tmp", i)
-		if err := ioutil.WriteFile(fn, invalidJSONBytes[i], 0644); err != nil {
+		if err := os.WriteFile(fn, invalidJSONBytes[i], 0644); err != nil {
 			fmt.Printf("Could not write file: %s", err)
 		}
 		var mb Metablock

--- a/in_toto/runlib.go
+++ b/in_toto/runlib.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -44,7 +44,7 @@ normalized to Unix-style line separators (LF) before hashing file contents.
 func RecordArtifact(path string, hashAlgorithms []string, lineNormalization bool) (map[string]interface{}, error) {
 	supportedHashMappings := getHashMapping()
 	// Read file from passed path
-	contents, err := ioutil.ReadFile(path)
+	contents, err := os.ReadFile(path)
 	hashedContentsMap := make(map[string]interface{})
 	if err != nil {
 		return nil, err
@@ -289,8 +289,8 @@ func RunCommand(cmdArgs []string, runDir string) (map[string]interface{}, error)
 	}
 
 	// TODO: duplicate stdout, stderr
-	stdout, _ := ioutil.ReadAll(stdoutPipe)
-	stderr, _ := ioutil.ReadAll(stderrPipe)
+	stdout, _ := io.ReadAll(stdoutPipe)
+	stderr, _ := io.ReadAll(stderrPipe)
 
 	retVal := waitErrToExitCode(cmd.Wait())
 

--- a/in_toto/runlib_test.go
+++ b/in_toto/runlib_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -210,7 +209,7 @@ func TestSymlinkToFolder(t *testing.T) {
 	// not work correctly on Windows
 	p := filepath.FromSlash("symTest/symTest2/symTmpfile")
 
-	if err := ioutil.WriteFile(p, []byte("abc"), 0400); err != nil {
+	if err := os.WriteFile(p, []byte("abc"), 0400); err != nil {
 		t.Errorf("could not write symTmpfile: %s", err)
 	}
 
@@ -285,7 +284,7 @@ func TestRecordArtifacts(t *testing.T) {
 	if err := os.Mkdir("tmpdir", 0700); err != nil {
 		t.Errorf("could not create tmpdir: %s", err)
 	}
-	if err := ioutil.WriteFile("tmpdir/tmpfile", []byte("abc"), 0400); err != nil {
+	if err := os.WriteFile("tmpdir/tmpfile", []byte("abc"), 0400); err != nil {
 		t.Errorf("could not write tmpfile: %s", err)
 	}
 	result, err := RecordArtifacts([]string{"foo.tar.gz",
@@ -303,7 +302,7 @@ func TestRecordArtifacts(t *testing.T) {
 			result, err, expected)
 	}
 	// Test duplicated artifact after left strip
-	if err := ioutil.WriteFile("tmpdir/foo.tar.gz", []byte("abc"), 0400); err != nil {
+	if err := os.WriteFile("tmpdir/foo.tar.gz", []byte("abc"), 0400); err != nil {
 		t.Errorf("could not write tmpfile: %s", err)
 	}
 	_, err = RecordArtifacts([]string{"foo.tar.gz",

--- a/in_toto/util_test.go
+++ b/in_toto/util_test.go
@@ -1,7 +1,6 @@
 package in_toto
 
 import (
-	"io/ioutil"
 	"os"
 	"reflect"
 	"sort"
@@ -115,11 +114,11 @@ func TestSubsetCheck(t *testing.T) {
 }
 
 func TestIsWritable(t *testing.T) {
-	notWritable, err := ioutil.TempDir("", "")
+	notWritable, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Error(err)
 	}
-	writable, err := ioutil.TempDir("", "")
+	writable, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
**Fixes issue:**
N/A
**Description:**
Replaces uses of ioutil with io / os as appropriate. io/ioutil has been deprecated for a few go versions now.

**Please verify and check that the pull request fulfills the following
requirements:**

- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


