### PR TITLE
Update maintainers and governance

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,19 @@
+# in-toto Governance
+
+in-toto's
+[governance](https://github.com/in-toto/community/blob/main/GOVERNANCE.md) and
+[code of conduct](https://github.com/in-toto/community/blob/main/CODE-OF-CONDUCT.md)
+are described in the [in-toto/community](https://github.com/in-toto/community)
+repository.
+
+## in-toto-golang Contributions
+
+This implementation adheres to
+[in-toto's contributing guidelines](https://github.com/in-toto/community/blob/main/CONTRIBUTING.md).
+Pull requests must be submitted to the `master` branch where they undergo
+review and automated testing, including, but not limited to:
+* Unit and build testing on
+  [GitHub Actions](https://github.com/in-toto/in-toto/actions)
+* Static code analysis via
+  [golangci-lint](https://github.com/golangci/golangci-lint)
+* Review by one or more [maintainers](MAINTAINERS.md)

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,8 +1,9 @@
 # Maintainers
 
-This document lists all maintainers and their GPG fingerprints.
-All releases have been signed with a GPG signature from one of these people.
-
+This project is managed by the
+[in-toto Steering Committee](https://github.com/in-toto/community/blob/main/GOVERNANCE.md).
+It is maintained by the following developers. All releases have been signed with
+a GPG signature from one of these people.
 
 * Santiago Torres
     * Email: santiagotorres@purdue.edu


### PR DESCRIPTION
Adds ITSC to maintainers.md, governance pointing to in-toto/community.