### PR TITLE
Add match products feature

### DIFF
--- a/cmd/match_products.go
+++ b/cmd/match_products.go
@@ -1,0 +1,95 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/in-toto/in-toto-golang/in_toto"
+	"github.com/spf13/cobra"
+)
+
+var matchProductsCmd = &cobra.Command{
+	Use:   "match-products",
+	Short: "Check if local artifacts match products in passed link",
+	RunE:  matchProducts,
+}
+
+var (
+	linkMetadataPath string
+	paths            []string
+)
+
+func init() {
+	rootCmd.AddCommand(matchProductsCmd)
+
+	matchProductsCmd.Flags().StringVarP(
+		&linkMetadataPath,
+		"link",
+		"l",
+		"",
+		"Path to link metadata file",
+	)
+	matchProductsCmd.MarkFlagRequired("link") //nolint:errcheck
+
+	matchProductsCmd.Flags().StringArrayVarP(
+		&paths,
+		"path",
+		"p",
+		[]string{"."},
+		"file or directory paths to local artifacts, default is CWD",
+	)
+
+	matchProductsCmd.Flags().StringArrayVarP(
+		&exclude,
+		"exclude",
+		"e",
+		[]string{},
+		"gitignore-style patterns to exclude artifacts from matching",
+	)
+
+	matchProductsCmd.Flags().StringArrayVar(
+		&lStripPaths,
+		"lstrip-paths",
+		[]string{},
+		`Path prefixes used to left-strip artifact paths before storing
+them to the resulting link metadata. If multiple prefixes
+are specified, only a single prefix can match the path of
+any artifact and that is then left-stripped. All prefixes
+are checked to ensure none of them are a left substring
+of another.`,
+	)
+}
+
+func matchProducts(cmd *cobra.Command, args []string) error {
+	linkEnv, err := in_toto.LoadMetadata(linkMetadataPath)
+	if err != nil {
+		return err
+	}
+
+	link, ok := linkEnv.GetPayload().(in_toto.Link)
+	if !ok {
+		return fmt.Errorf("metadata must be link")
+	}
+
+	onlyInProducts, notInProducts, differ, err := in_toto.InTotoMatchProducts(&link, paths, []string{"sha256"}, exclude, lStripPaths)
+	if err != nil {
+		return err
+	}
+
+	if len(onlyInProducts) != 0 || len(notInProducts) != 0 || len(differ) != 0 {
+		for _, name := range onlyInProducts {
+			fmt.Printf("Only in products: %s\n", name)
+		}
+
+		for _, name := range notInProducts {
+			fmt.Printf("Not in products: %s\n", name)
+		}
+
+		for _, name := range differ {
+			fmt.Printf("Hashes differ: %s\n", name)
+		}
+		os.Exit(1)
+	}
+
+	return nil
+}

--- a/doc/in-toto.md
+++ b/doc/in-toto.md
@@ -17,6 +17,7 @@ A framework to secure the integrity of software supply chains https://in-toto.io
 * [in-toto completion](in-toto_completion.md)	 - Generate completion script
 * [in-toto gendoc](in-toto_gendoc.md)	 - Generate in-toto-golang's help docs
 * [in-toto key](in-toto_key.md)	 - Key management commands
+* [in-toto match-products](in-toto_match-products.md)	 - Check if local artifacts match products in passed link
 * [in-toto record](in-toto_record.md)	 - Creates a signed link metadata file in two steps, in order to provide
               evidence for supply chain steps that cannot be carried out by a single command
 * [in-toto run](in-toto_run.md)	 - Executes the passed command and records paths and hashes of 'materials'

--- a/doc/in-toto_match-products.md
+++ b/doc/in-toto_match-products.md
@@ -1,0 +1,27 @@
+## in-toto match-products
+
+Check if local artifacts match products in passed link
+
+```
+in-toto match-products [flags]
+```
+
+### Options
+
+```
+  -e, --exclude stringArray        gitignore-style patterns to exclude artifacts from matching
+  -h, --help                       help for match-products
+  -l, --link string                Path to link metadata file
+      --lstrip-paths stringArray   Path prefixes used to left-strip artifact paths before storing
+                                   them to the resulting link metadata. If multiple prefixes
+                                   are specified, only a single prefix can match the path of
+                                   any artifact and that is then left-stripped. All prefixes
+                                   are checked to ensure none of them are a left substring
+                                   of another.
+  -p, --path stringArray           file or directory paths to local artifacts, default is CWD (default [.])
+```
+
+### SEE ALSO
+
+* [in-toto](in-toto.md)	 - Framework to secure integrity of software supply chains
+


### PR DESCRIPTION
**Fixes issue:** N/A


**Description:**

This PR adds InTotoMatchProducts which accepts a link metadata file and checks if local artifacts match those recorded as the link's products.

See: https://github.com/in-toto/in-toto/pull/589

**Please verify and check that the pull request fulfills the following
requirements:**

- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


