### PR TITLE
Drop use of `any` for hash objects

### DIFF
--- a/in_toto/attestations_test.go
+++ b/in_toto/attestations_test.go
@@ -429,10 +429,10 @@ func TestLinkStatement(t *testing.T) {
     "name": "name",
     "command": ["cc", "-o", "baz", "baz.z"],
     "materials": {
-       "kv": "vv"
+       "kv": {"alg": "vv"}
     },
     "products": {
-       "kp": "vp"
+       "kp": {"alg": "vp"}
     },
     "byproducts": {
        "kb": "vb"
@@ -459,11 +459,11 @@ func TestLinkStatement(t *testing.T) {
 		Predicate: Link{
 			Type: "link",
 			Name: "name",
-			Materials: map[string]interface{}{
-				"kv": "vv",
+			Materials: map[string]HashObj{
+				"kv": {"alg": "vv"},
 			},
-			Products: map[string]interface{}{
-				"kp": "vp",
+			Products: map[string]HashObj{
+				"kp": {"alg": "vp"},
 			},
 			ByProducts: map[string]interface{}{
 				"kb": "vb",

--- a/in_toto/envelope_test.go
+++ b/in_toto/envelope_test.go
@@ -30,8 +30,8 @@ func TestEnvelopeSetPayload(t *testing.T) {
 		payload := Link{
 			Type:        "link",
 			Name:        "test",
-			Materials:   map[string]any{},
-			Products:    map[string]any{},
+			Materials:   map[string]HashObj{},
+			Products:    map[string]HashObj{},
 			ByProducts:  map[string]any{},
 			Environment: map[string]any{},
 			Command:     []string{},
@@ -67,8 +67,8 @@ func TestEnvelopeGetPayload(t *testing.T) {
 		payload := Link{
 			Type:        "link",
 			Name:        "test",
-			Materials:   map[string]any{},
-			Products:    map[string]any{},
+			Materials:   map[string]HashObj{},
+			Products:    map[string]HashObj{},
 			ByProducts:  map[string]any{},
 			Environment: map[string]any{},
 			Command:     []string{},
@@ -86,8 +86,8 @@ func TestEnvelopeGetPayload(t *testing.T) {
 		payload := Link{
 			Type:        "link",
 			Name:        "test",
-			Materials:   map[string]any{},
-			Products:    map[string]any{},
+			Materials:   map[string]HashObj{},
+			Products:    map[string]HashObj{},
 			ByProducts:  map[string]any{},
 			Environment: map[string]any{},
 			Command:     []string{},

--- a/in_toto/model.go
+++ b/in_toto/model.go
@@ -18,6 +18,8 @@ import (
 	"github.com/secure-systems-lab/go-securesystemslib/dsse"
 )
 
+type HashObj = map[string]string
+
 /*
 KeyVal contains the actual values of a key, as opposed to key metadata such as
 a key identifier or key type.  For RSA keys, the key value is a pair of public
@@ -337,8 +339,8 @@ writing to disk.
 type Link struct {
 	Type        string                 `json:"_type"`
 	Name        string                 `json:"name"`
-	Materials   map[string]interface{} `json:"materials"`
-	Products    map[string]interface{} `json:"products"`
+	Materials   map[string]HashObj     `json:"materials"`
+	Products    map[string]HashObj     `json:"products"`
 	ByProducts  map[string]interface{} `json:"byproducts"`
 	Command     []string               `json:"command"`
 	Environment map[string]interface{} `json:"environment"`
@@ -347,7 +349,7 @@ type Link struct {
 /*
 validateArtifacts is a general function used to validate products and materials.
 */
-func validateArtifacts(artifacts map[string]interface{}) error {
+func validateArtifacts(artifacts map[string]HashObj) error {
 	for artifactName, artifact := range artifacts {
 		artifactValue := reflect.ValueOf(artifact).MapRange()
 		for artifactValue.Next() {

--- a/in_toto/model_test.go
+++ b/in_toto/model_test.go
@@ -178,13 +178,13 @@ func TestMetablockLoadDumpLoad(t *testing.T) {
 				"foo.tar.gz",
 				"foo.py",
 			},
-			Materials: map[string]interface{}{
-				"foo.py": map[string]interface{}{
+			Materials: map[string]HashObj{
+				"foo.py": {
 					"sha256": "74dc3727c6e89308b39e4dfedf787e37841198b1fa165a27c013544a60502549",
 				},
 			},
-			Products: map[string]interface{}{
-				"foo.tar.gz": map[string]interface{}{
+			Products: map[string]HashObj{
+				"foo.tar.gz": {
 					"sha256": "52947cb78b91ad01fe81cd6aef42d1f6817e92b9e6936c1e5aabb7c98514f355",
 				},
 			},
@@ -314,13 +314,13 @@ func TestValidateLink(t *testing.T) {
 				"foo.tar.gz",
 				"foo.py",
 			},
-			Materials: map[string]interface{}{
-				"foo.py": map[string]interface{}{
+			Materials: map[string]HashObj{
+				"foo.py": {
 					"sha256": "74dc3727c6e89308b39e4dfedf787e37841198b1fa165a27c013544a60502549",
 				},
 			},
-			Products: map[string]interface{}{
-				"foo.tar.gz": map[string]interface{}{
+			Products: map[string]HashObj{
+				"foo.tar.gz": {
 					"sha256": "52947cb78b91ad01fe81cd6aef42d1f6817e92b9e6936c1e5aabb7c98514f355",
 				},
 			},
@@ -348,13 +348,13 @@ func TestValidateLink(t *testing.T) {
 				"foo.tar.gz",
 				"foo.py",
 			},
-			Materials: map[string]interface{}{
-				"foo.py": map[string]interface{}{
+			Materials: map[string]HashObj{
+				"foo.py": {
 					"sha256": "!@#$%",
 				},
 			},
-			Products: map[string]interface{}{
-				"foo.tar.gz": map[string]interface{}{
+			Products: map[string]HashObj{
+				"foo.tar.gz": {
 					"sha256": "52947cb78b91ad01fe81cd6aef42d1f6817e92b9e69" +
 						"36c1e5aabb7c98514f355",
 				},
@@ -384,13 +384,13 @@ func TestValidateLink(t *testing.T) {
 				"foo.tar.gz",
 				"foo.py",
 			},
-			Materials: map[string]interface{}{
-				"foo.py": map[string]interface{}{
+			Materials: map[string]HashObj{
+				"foo.py": {
 					"sha256": "74dc3727c6e89308b39e4dfedf787e37841198b1fa165a27c013544a60502549",
 				},
 			},
-			Products: map[string]interface{}{
-				"foo.tar.gz": map[string]interface{}{
+			Products: map[string]HashObj{
+				"foo.tar.gz": {
 					"sha256": "!@#$%",
 				},
 			},
@@ -863,14 +863,14 @@ func TestValidateMetablock(t *testing.T) {
 				"foo.tar.gz",
 				"foo.py",
 			},
-			Materials: map[string]interface{}{
-				"foo.py": map[string]interface{}{
+			Materials: map[string]HashObj{
+				"foo.py": {
 					"sha256": "74dc3727c6e89308b39e4dfedf787e37841198b1fa165a" +
 						"27c013544a60502549",
 				},
 			},
-			Products: map[string]interface{}{
-				"foo.tar.gz": map[string]interface{}{
+			Products: map[string]HashObj{
+				"foo.tar.gz": {
 					"sha256": "52947cb78b91ad01fe81cd6aef42d1f6817e92b9e6936c" +
 						"1e5aabb7c98514f355",
 				},
@@ -954,14 +954,14 @@ func TestValidateMetablock(t *testing.T) {
 				"foo.tar.gz",
 				"foo.py",
 			},
-			Materials: map[string]interface{}{
-				"foo.py": map[string]interface{}{
+			Materials: map[string]HashObj{
+				"foo.py": {
 					"sha256": "74dc3727c6e89308b39e4dfedf787e37841198b1fa165a" +
 						"27c013544a60502549",
 				},
 			},
-			Products: map[string]interface{}{
-				"foo.tar.gz": map[string]interface{}{
+			Products: map[string]HashObj{
+				"foo.tar.gz": {
 					"sha256": "52947cb78b91ad01fe81cd6aef42d1f6817e92b9e6936c" +
 						"1e5aabb7c98514f355",
 				},

--- a/in_toto/runlib_test.go
+++ b/in_toto/runlib_test.go
@@ -25,7 +25,7 @@ func testOSisWindows() bool {
 func TestRecordArtifact(t *testing.T) {
 	// Test successfully record one artifact
 	result, err := RecordArtifact("foo.tar.gz", []string{"sha256"}, testOSisWindows())
-	expected := map[string]interface{}{
+	expected := HashObj{
 		"sha256": "52947cb78b91ad01fe81cd6aef42d1f6817e92b9e6936c1e5aabb7c98514f355",
 	}
 	if !reflect.DeepEqual(result, expected) || err != nil {
@@ -100,7 +100,7 @@ func TestGitPathSpec(t *testing.T) {
 		}
 	}
 
-	expected := map[string]interface{}{}
+	expected := map[string]HashObj{}
 	// Let's start our test in the test/data directory
 	result, err := RecordArtifacts([]string{"pathSpecTest"}, []string{"sha256"}, []string{
 		"*.pub",           // Match all .pub files (even the ones in subdirectories)
@@ -129,8 +129,8 @@ func TestSymlinkToFile(t *testing.T) {
 		t.Errorf("could not create a symlink: %s", err)
 	}
 
-	expected := map[string]interface{}{
-		"foo.tar.gz.sym": map[string]interface{}{
+	expected := map[string]HashObj{
+		"foo.tar.gz.sym": {
 			"sha256": "52947cb78b91ad01fe81cd6aef42d1f6817e92b9e6936c1e5aabb7c98514f355",
 		},
 	}
@@ -221,8 +221,8 @@ func TestSymlinkToFolder(t *testing.T) {
 		t.Error(err)
 	}
 
-	expected := map[string]interface{}{
-		path.Join("symTmpfile.sym", "symTmpfile"): map[string]interface{}{
+	expected := map[string]HashObj{
+		path.Join("symTmpfile.sym", "symTmpfile"): {
 			"sha256": "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
 		},
 	}
@@ -292,11 +292,11 @@ func TestRecordArtifacts(t *testing.T) {
 	}
 	result, err := RecordArtifacts([]string{"foo.tar.gz",
 		"tmpdir/tmpfile"}, []string{"sha256"}, nil, []string{"tmpdir/"}, testOSisWindows(), false)
-	expected := map[string]interface{}{
-		"foo.tar.gz": map[string]interface{}{
+	expected := map[string]HashObj{
+		"foo.tar.gz": {
 			"sha256": "52947cb78b91ad01fe81cd6aef42d1f6817e92b9e6936c1e5aabb7c98514f355",
 		},
-		"tmpfile": map[string]interface{}{
+		"tmpfile": {
 			"sha256": "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
 		},
 	}
@@ -418,13 +418,13 @@ func TestInTotoRun(t *testing.T) {
 			Signed: Link{
 				Name: linkName,
 				Type: "link",
-				Materials: map[string]interface{}{
-					"alice.pub": map[string]interface{}{
+				Materials: map[string]HashObj{
+					"alice.pub": {
 						"sha256": "f051e8b561835b7b2aa7791db7bc72f2613411b0b7d428a0ac33d45b8c518039",
 					},
 				},
-				Products: map[string]interface{}{
-					"foo.tar.gz": map[string]interface{}{
+				Products: map[string]HashObj{
+					"foo.tar.gz": {
 						"sha256": "52947cb78b91ad01fe81cd6aef42d1f6817e92b9e6936c1e5aabb7c98514f355",
 					},
 				},
@@ -444,13 +444,13 @@ func TestInTotoRun(t *testing.T) {
 			Signed: Link{
 				Name: linkName,
 				Type: "link",
-				Materials: map[string]interface{}{
-					"alice.pub": map[string]interface{}{
+				Materials: map[string]HashObj{
+					"alice.pub": {
 						"sha256": "f051e8b561835b7b2aa7791db7bc72f2613411b0b7d428a0ac33d45b8c518039",
 					},
 				},
-				Products: map[string]interface{}{
-					"foo.tar.gz": map[string]interface{}{
+				Products: map[string]HashObj{
+					"foo.tar.gz": HashObj{
 						"sha256": "52947cb78b91ad01fe81cd6aef42d1f6817e92b9e6936c1e5aabb7c98514f355",
 					},
 				},
@@ -556,12 +556,12 @@ func TestInTotoRecord(t *testing.T) {
 			Signed: Link{
 				Name: linkName,
 				Type: "link",
-				Materials: map[string]interface{}{
-					"alice.pub": map[string]interface{}{
+				Materials: map[string]HashObj{
+					"alice.pub": {
 						"sha256": "f051e8b561835b7b2aa7791db7bc72f2613411b0b7d428a0ac33d45b8c518039",
 					},
 				},
-				Products:    map[string]interface{}{},
+				Products:    map[string]HashObj{},
 				ByProducts:  map[string]interface{}{},
 				Command:     []string{},
 				Environment: map[string]interface{}{},
@@ -574,13 +574,13 @@ func TestInTotoRecord(t *testing.T) {
 			Signed: Link{
 				Name: linkName,
 				Type: "link",
-				Materials: map[string]interface{}{
-					"alice.pub": map[string]interface{}{
+				Materials: map[string]HashObj{
+					"alice.pub": {
 						"sha256": "f051e8b561835b7b2aa7791db7bc72f2613411b0b7d428a0ac33d45b8c518039",
 					},
 				},
-				Products: map[string]interface{}{
-					"foo.tar.gz": map[string]interface{}{
+				Products: map[string]HashObj{
+					"foo.tar.gz": {
 						"sha256": "52947cb78b91ad01fe81cd6aef42d1f6817e92b9e6936c1e5aabb7c98514f355",
 					},
 				},
@@ -643,7 +643,7 @@ func TestRecordArtifactWithBlobs(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    map[string]interface{}
+		want    HashObj
 		wantErr error
 	}{
 		{
@@ -652,7 +652,7 @@ func TestRecordArtifactWithBlobs(t *testing.T) {
 				path:           "foo.tar.gz",
 				hashAlgorithms: []string{"sha256", "sha384", "sha512"},
 			},
-			want: map[string]interface{}{"sha256": "52947cb78b91ad01fe81cd6aef42d1f6817e92b9e6936c1e5aabb7c98514f355",
+			want: HashObj{"sha256": "52947cb78b91ad01fe81cd6aef42d1f6817e92b9e6936c1e5aabb7c98514f355",
 				"sha384": "ce17464027a7d7c15b15032b404fc76fdbadfa1fa566d7f7747020df2542a293b3098873a98dbbda6e461f7767b8ff6c",
 				"sha512": "bb040966a5a6aefb646909f636f7f99c9e16b684a1f0e83a87dc30c3ab4d9dec2f9b0091d8be74bbc78ba29cb0c2dd027c223579028cf9822b0bccc49d493a6d"},
 			wantErr: nil,
@@ -663,7 +663,7 @@ func TestRecordArtifactWithBlobs(t *testing.T) {
 				path:           "helloworld",
 				hashAlgorithms: []string{"sha256", "sha384", "sha512"},
 			},
-			want: map[string]interface{}{"sha256": "fd895747460401ca62d81f310538110734ff5401f8ef86c3ab27168598225db8",
+			want: HashObj{"sha256": "fd895747460401ca62d81f310538110734ff5401f8ef86c3ab27168598225db8",
 				"sha384": "ddc3ac40ca8d04929e13c42d555a5a6774d35bfac9e2f4cde5847ab3f12f36831faa3baf1b33922b53d288b352ae4b9a",
 				"sha512": "46f0e37e72879843f95ddecc4d511c9ba90241c34b471c2f2caca2784abe185da50ddc5252562b2a911b7cfedafa3e878f0e6b7aa843c136915da5306061e501"},
 			wantErr: nil,
@@ -728,7 +728,7 @@ func TestLineNormalizationFlag(t *testing.T) {
 			wantErr: nil,
 		},
 	}
-	expected := map[string]interface{}{
+	expected := HashObj{
 		"sha256": "efb929dfabd55c93796fc61cbf1fe6157445f093167dbee82e8b069842a4fceb",
 		"sha384": "936e88775dfd17c24ed41e3a896dfdf3395707acee1b6f16a52ae144bdcd8611fd17e817f5b75e5a3cf7a1dacf187bae",
 		"sha512": "1d7a485cb2c3cf22c11b4be9afbf1745e053e21a40301d3e8143350d6d2873117c12acef49d4b3650b5262e8a26ffe809b177f968845bd268f26ffd978d314bd",
@@ -749,14 +749,14 @@ func TestLineNormalizationFlag(t *testing.T) {
 
 func TestInTotoMatchProducts(t *testing.T) {
 	link := &Link{
-		Products: map[string]any{
-			"foo": map[string]string{
+		Products: map[string]HashObj{
+			"foo": {
 				"sha256": "8a51c03f1ff77c2b8e76da512070c23c5e69813d5c61732b3025199e5f0c14d5",
 			},
-			"bar": map[string]string{
+			"bar": {
 				"sha256": "bb97edb3507a35b119539120526d00da595f14575da261cd856389ecd89d3186",
 			},
-			"baz": map[string]string{
+			"baz": {
 				"sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 			},
 		},

--- a/in_toto/util.go
+++ b/in_toto/util.go
@@ -121,10 +121,10 @@ func (s Set) Slice() []string {
 }
 
 /*
-InterfaceKeyStrings returns string keys of passed interface{} map in an
+artifactsDictKeyStrings returns string keys of passed HashObj map in an
 unordered string slice.
 */
-func InterfaceKeyStrings(m map[string]interface{}) []string {
+func artifactsDictKeyStrings(m map[string]HashObj) []string {
 	res := make([]string, len(m))
 	i := 0
 	for k := range m {

--- a/in_toto/util_test.go
+++ b/in_toto/util_test.go
@@ -84,10 +84,10 @@ func TestSetFilter(t *testing.T) {
 	}
 }
 
-func TestInterfaceKeyStrings(t *testing.T) {
+func TestArtifactsDictKeyStrings(t *testing.T) {
 	expected := []string{"a", "b", "c"}
-	testMap := map[string]interface{}{"a": nil, "b": nil, "c": nil}
-	res := InterfaceKeyStrings(testMap)
+	testMap := map[string]HashObj{"a": nil, "b": nil, "c": nil}
+	res := artifactsDictKeyStrings(testMap)
 	sort.Strings(res)
 	if !reflect.DeepEqual(res, expected) {
 		t.Errorf("expected: %s, got: %s", expected, res)

--- a/in_toto/verifylib.go
+++ b/in_toto/verifylib.go
@@ -80,7 +80,7 @@ func RunInspections(layout Layout, runDir string, lineNormalization bool, useDSS
 // verifyMatchRule is a helper function to process artifact rules of
 // type MATCH. See VerifyArtifacts for more details.
 func verifyMatchRule(ruleData map[string]string,
-	srcArtifacts map[string]interface{}, srcArtifactQueue Set,
+	srcArtifacts map[string]HashObj, srcArtifactQueue Set,
 	itemsMetadata map[string]Metadata) Set {
 	consumed := NewSet()
 	// Get destination link metadata
@@ -92,7 +92,7 @@ func verifyMatchRule(ruleData map[string]string,
 	}
 
 	// Get artifacts from destination link metadata
-	var dstArtifacts map[string]interface{}
+	var dstArtifacts map[string]HashObj
 	switch ruleData["dstType"] {
 	case "materials":
 		dstArtifacts = dstLinkEnv.GetPayload().(Link).Materials
@@ -223,11 +223,11 @@ func VerifyArtifacts(items []interface{},
 		// hashes). We extract them from the corresponding maps and store them as
 		// sets for convenience in further processing
 		materialPaths := NewSet()
-		for _, p := range InterfaceKeyStrings(materials) {
+		for _, p := range artifactsDictKeyStrings(materials) {
 			materialPaths.Add(path.Clean(p))
 		}
 		productPaths := NewSet()
-		for _, p := range InterfaceKeyStrings(products) {
+		for _, p := range artifactsDictKeyStrings(products) {
 			productPaths.Add(path.Clean(p))
 		}
 
@@ -270,7 +270,7 @@ func VerifyArtifacts(items []interface{},
 			// fmt.Printf("%s...\n", verificationData["srcType"])
 
 			rules := verificationData["rules"].([][]string)
-			artifacts := verificationData["artifacts"].(map[string]interface{})
+			artifacts := verificationData["artifacts"].(map[string]HashObj)
 
 			// Use artifacts (without hashes) as base queue. Each rule only operates
 			// on artifacts in that queue.  If a rule consumes an artifact (i.e. can

--- a/in_toto/verifylib_test.go
+++ b/in_toto/verifylib_test.go
@@ -254,8 +254,8 @@ func TestRunInspections(t *testing.T) {
 		sort.Strings(availableFiles)
 		// Compare material and products (only file names) to files that were
 		// in the directory before calling RunInspections
-		materialNames := InterfaceKeyStrings(result[inspectionName].GetPayload().(Link).Materials)
-		productNames := InterfaceKeyStrings(result[inspectionName].GetPayload().(Link).Products)
+		materialNames := artifactsDictKeyStrings(result[inspectionName].GetPayload().(Link).Materials)
+		productNames := artifactsDictKeyStrings(result[inspectionName].GetPayload().(Link).Products)
 		sort.Strings(materialNames)
 		sort.Strings(productNames)
 		if !reflect.DeepEqual(materialNames, availableFiles) ||
@@ -341,17 +341,17 @@ func TestVerifyArtifact(t *testing.T) {
 				"foo": &Metablock{
 					Signed: Link{
 						Name: "foo",
-						Materials: map[string]interface{}{
-							"foo-delete": map[string]interface{}{"sha265": "abc"},
-							"foo-modify": map[string]interface{}{"sha265": "abc"},
-							"foo-match":  map[string]interface{}{"sha265": "abc"},
-							"foo-allow":  map[string]interface{}{"sha265": "abc"},
+						Materials: map[string]HashObj{
+							"foo-delete": {"sha265": "abc"},
+							"foo-modify": {"sha265": "abc"},
+							"foo-match":  {"sha265": "abc"},
+							"foo-allow":  {"sha265": "abc"},
 						},
-						Products: map[string]interface{}{
-							"foo-create": map[string]interface{}{"sha265": "abc"},
-							"foo-modify": map[string]interface{}{"sha265": "abcdef"},
-							"foo-match":  map[string]interface{}{"sha265": "abc"},
-							"foo-allow":  map[string]interface{}{"sha265": "abc"},
+						Products: map[string]HashObj{
+							"foo-create": {"sha265": "abc"},
+							"foo-modify": {"sha265": "abcdef"},
+							"foo-match":  {"sha265": "abc"},
+							"foo-allow":  {"sha265": "abc"},
 						},
 					},
 				},
@@ -375,18 +375,18 @@ func TestVerifyArtifact(t *testing.T) {
 				"foo": &Metablock{
 					Signed: Link{
 						Name: "foo",
-						Materials: map[string]interface{}{
-							"./foo.d/foo.py": map[string]interface{}{"sha265": "abc"},
-							"bar.d/bar.py":   map[string]interface{}{"sha265": "abc"},
+						Materials: map[string]HashObj{
+							"./foo.d/foo.py": {"sha265": "abc"},
+							"bar.d/bar.py":   {"sha265": "abc"},
 						},
 					},
 				},
 				"bar": &Metablock{
 					Signed: Link{
 						Name: "bar",
-						Products: map[string]interface{}{
-							"foo.d/foo.py":          map[string]interface{}{"sha265": "abc"},
-							"./baz/../bar.d/bar.py": map[string]interface{}{"sha265": "abc"},
+						Products: map[string]HashObj{
+							"foo.d/foo.py":          {"sha265": "abc"},
+							"./baz/../bar.d/bar.py": {"sha265": "abc"},
 						},
 					},
 				},
@@ -410,18 +410,18 @@ func TestVerifyArtifact(t *testing.T) {
 				"foo": &Metablock{
 					Signed: Link{
 						Name: "foo",
-						Materials: map[string]interface{}{
-							"foo.d/foo.py": map[string]interface{}{"sha265": "abc"},
-							"bar.d/bar.py": map[string]interface{}{"sha265": "def"}, // modified by mitm
+						Materials: map[string]HashObj{
+							"foo.d/foo.py": {"sha265": "abc"},
+							"bar.d/bar.py": {"sha265": "def"}, // modified by mitm
 						},
 					},
 				},
 				"bar": &Metablock{
 					Signed: Link{
 						Name: "bar",
-						Products: map[string]interface{}{
-							"foo.d/foo.py": map[string]interface{}{"sha265": "abc"},
-							"bar.d/bar.py": map[string]interface{}{"sha265": "abc"},
+						Products: map[string]HashObj{
+							"foo.d/foo.py": {"sha265": "abc"},
+							"bar.d/bar.py": {"sha265": "abc"},
 						},
 					},
 				},
@@ -473,97 +473,97 @@ func TestVerifyArtifact(t *testing.T) {
 		{
 			name:      "Disallowed material in step",
 			item:      []interface{}{Step{SupplyChainItem: SupplyChainItem{Name: "foo", ExpectedMaterials: [][]string{{"DISALLOW", "*"}}}}},
-			metadata:  map[string]Metadata{"foo": &Metablock{Signed: Link{Name: "foo", Materials: map[string]interface{}{"foo.py": map[string]interface{}{"sha265": "abc"}}}}},
+			metadata:  map[string]Metadata{"foo": &Metablock{Signed: Link{Name: "foo", Materials: map[string]HashObj{"foo.py": {"sha265": "abc"}}}}},
 			expectErr: "materials [foo.py] disallowed by rule",
 		},
 		{
 			name:      "Disallowed product in step",
 			item:      []interface{}{Step{SupplyChainItem: SupplyChainItem{Name: "foo", ExpectedProducts: [][]string{{"DISALLOW", "*"}}}}},
-			metadata:  map[string]Metadata{"foo": &Metablock{Signed: Link{Name: "foo", Products: map[string]interface{}{"foo.py": map[string]interface{}{"sha265": "abc"}}}}},
+			metadata:  map[string]Metadata{"foo": &Metablock{Signed: Link{Name: "foo", Products: map[string]HashObj{"foo.py": {"sha265": "abc"}}}}},
 			expectErr: "products [foo.py] disallowed by rule",
 		},
 		{
 			name:      "Disallowed material in inspection",
 			item:      []interface{}{Inspection{SupplyChainItem: SupplyChainItem{Name: "foo", ExpectedMaterials: [][]string{{"DISALLOW", "*"}}}}},
-			metadata:  map[string]Metadata{"foo": &Metablock{Signed: Link{Name: "foo", Materials: map[string]interface{}{"foo.py": map[string]interface{}{"sha265": "abc"}}}}},
+			metadata:  map[string]Metadata{"foo": &Metablock{Signed: Link{Name: "foo", Materials: map[string]HashObj{"foo.py": {"sha265": "abc"}}}}},
 			expectErr: "materials [foo.py] disallowed by rule",
 		},
 		{
 			name:      "Disallowed product in inspection",
 			item:      []interface{}{Inspection{SupplyChainItem: SupplyChainItem{Name: "foo", ExpectedProducts: [][]string{{"DISALLOW", "*"}}}}},
-			metadata:  map[string]Metadata{"foo": &Metablock{Signed: Link{Name: "foo", Products: map[string]interface{}{"foo.py": map[string]interface{}{"sha265": "abc"}}}}},
+			metadata:  map[string]Metadata{"foo": &Metablock{Signed: Link{Name: "foo", Products: map[string]HashObj{"foo.py": {"sha265": "abc"}}}}},
 			expectErr: "products [foo.py] disallowed by rule",
 		},
 		{
 			name:      "Required but missing material in step",
 			item:      []interface{}{Step{SupplyChainItem: SupplyChainItem{Name: "foo", ExpectedMaterials: [][]string{{"REQUIRE", "foo"}}}}},
-			metadata:  map[string]Metadata{"foo": &Metablock{Signed: Link{Name: "foo", Materials: map[string]interface{}{"foo.py": map[string]interface{}{"sha265": "abc"}}}}},
+			metadata:  map[string]Metadata{"foo": &Metablock{Signed: Link{Name: "foo", Materials: map[string]HashObj{"foo.py": {"sha265": "abc"}}}}},
 			expectErr: "materials in REQUIRE 'foo'",
 		},
 		{
 			name:      "Required but missing product in step",
 			item:      []interface{}{Step{SupplyChainItem: SupplyChainItem{Name: "foo", ExpectedProducts: [][]string{{"REQUIRE", "foo"}}}}},
-			metadata:  map[string]Metadata{"foo": &Metablock{Signed: Link{Name: "foo", Products: map[string]interface{}{"foo.py": map[string]interface{}{"sha265": "abc"}}}}},
+			metadata:  map[string]Metadata{"foo": &Metablock{Signed: Link{Name: "foo", Products: map[string]HashObj{"foo.py": {"sha265": "abc"}}}}},
 			expectErr: "products in REQUIRE 'foo'",
 		},
 		{
 			name:      "Required but missing material in inspection",
 			item:      []interface{}{Inspection{SupplyChainItem: SupplyChainItem{Name: "foo", ExpectedMaterials: [][]string{{"REQUIRE", "foo"}}}}},
-			metadata:  map[string]Metadata{"foo": &Metablock{Signed: Link{Name: "foo", Materials: map[string]interface{}{"foo.py": map[string]interface{}{"sha265": "abc"}}}}},
+			metadata:  map[string]Metadata{"foo": &Metablock{Signed: Link{Name: "foo", Materials: map[string]HashObj{"foo.py": {"sha265": "abc"}}}}},
 			expectErr: "materials in REQUIRE 'foo'",
 		},
 		{
 			name:      "Required but missing product in inspection",
 			item:      []interface{}{Inspection{SupplyChainItem: SupplyChainItem{Name: "foo", ExpectedProducts: [][]string{{"REQUIRE", "foo"}}}}},
-			metadata:  map[string]Metadata{"foo": &Metablock{Signed: Link{Name: "foo", Products: map[string]interface{}{"foo.py": map[string]interface{}{"sha265": "abc"}}}}},
+			metadata:  map[string]Metadata{"foo": &Metablock{Signed: Link{Name: "foo", Products: map[string]HashObj{"foo.py": {"sha265": "abc"}}}}},
 			expectErr: "products in REQUIRE 'foo'",
 		},
 		{
 			name:      "Disallowed subdirectory material in step",
 			item:      []interface{}{Step{SupplyChainItem: SupplyChainItem{Name: "foo", ExpectedMaterials: [][]string{{"DISALLOW", "*"}}}}},
-			metadata:  map[string]Metadata{"foo": &Metablock{Signed: Link{Name: "foo", Materials: map[string]interface{}{"dir/foo.py": map[string]interface{}{"sha265": "abc"}}}}},
+			metadata:  map[string]Metadata{"foo": &Metablock{Signed: Link{Name: "foo", Materials: map[string]HashObj{"dir/foo.py": {"sha265": "abc"}}}}},
 			expectErr: "materials [dir/foo.py] disallowed by rule",
 		},
 		{
 			name:      "Disallowed subdirectory product in step",
 			item:      []interface{}{Step{SupplyChainItem: SupplyChainItem{Name: "foo", ExpectedProducts: [][]string{{"DISALLOW", "*"}}}}},
-			metadata:  map[string]Metadata{"foo": &Metablock{Signed: Link{Name: "foo", Products: map[string]interface{}{"dir/foo.py": map[string]interface{}{"sha265": "abc"}}}}},
+			metadata:  map[string]Metadata{"foo": &Metablock{Signed: Link{Name: "foo", Products: map[string]HashObj{"dir/foo.py": {"sha265": "abc"}}}}},
 			expectErr: "products [dir/foo.py] disallowed by rule",
 		},
 		{
 			name:      "Disallowed subdirectory material in inspection",
 			item:      []interface{}{Inspection{SupplyChainItem: SupplyChainItem{Name: "foo", ExpectedMaterials: [][]string{{"DISALLOW", "*"}}}}},
-			metadata:  map[string]Metadata{"foo": &Metablock{Signed: Link{Name: "foo", Materials: map[string]interface{}{"dir/foo.py": map[string]interface{}{"sha265": "abc"}}}}},
+			metadata:  map[string]Metadata{"foo": &Metablock{Signed: Link{Name: "foo", Materials: map[string]HashObj{"dir/foo.py": {"sha265": "abc"}}}}},
 			expectErr: "materials [dir/foo.py] disallowed by rule",
 		},
 		{
 			name:      "Disallowed subdirectory product in inspection",
 			item:      []interface{}{Inspection{SupplyChainItem: SupplyChainItem{Name: "foo", ExpectedProducts: [][]string{{"DISALLOW", "*"}}}}},
-			metadata:  map[string]Metadata{"foo": &Metablock{Signed: Link{Name: "foo", Products: map[string]interface{}{"dir/foo.py": map[string]interface{}{"sha265": "abc"}}}}},
+			metadata:  map[string]Metadata{"foo": &Metablock{Signed: Link{Name: "foo", Products: map[string]HashObj{"dir/foo.py": {"sha265": "abc"}}}}},
 			expectErr: "products [dir/foo.py] disallowed by rule",
 		},
 		{
 			name:      "Consuming filename material in step",
 			item:      []interface{}{Step{SupplyChainItem: SupplyChainItem{Name: "foo", ExpectedMaterials: [][]string{{"ALLOW", "foo.py"}, {"DISALLOW", "*"}}}}},
-			metadata:  map[string]Metadata{"foo": &Metablock{Signed: Link{Name: "foo", Materials: map[string]interface{}{"./bar/..//foo.py": map[string]interface{}{"sha265": "abc"}}}}},
+			metadata:  map[string]Metadata{"foo": &Metablock{Signed: Link{Name: "foo", Materials: map[string]HashObj{"./bar/..//foo.py": {"sha265": "abc"}}}}},
 			expectErr: "",
 		},
 		{
 			name:      "Consuming filename product in step",
 			item:      []interface{}{Step{SupplyChainItem: SupplyChainItem{Name: "foo", ExpectedProducts: [][]string{{"ALLOW", "foo.py"}, {"DISALLOW", "*"}}}}},
-			metadata:  map[string]Metadata{"foo": &Metablock{Signed: Link{Name: "foo", Products: map[string]interface{}{"./bar/..//foo.py": map[string]interface{}{"sha265": "abc"}}}}},
+			metadata:  map[string]Metadata{"foo": &Metablock{Signed: Link{Name: "foo", Products: map[string]HashObj{"./bar/..//foo.py": {"sha265": "abc"}}}}},
 			expectErr: "",
 		},
 		{
 			name:      "Consuming filename material in inspection",
 			item:      []interface{}{Inspection{SupplyChainItem: SupplyChainItem{Name: "foo", ExpectedMaterials: [][]string{{"ALLOW", "foo.py"}, {"DISALLOW", "*"}}}}},
-			metadata:  map[string]Metadata{"foo": &Metablock{Signed: Link{Name: "foo", Materials: map[string]interface{}{"./bar/..//foo.py": map[string]interface{}{"sha265": "abc"}}}}},
+			metadata:  map[string]Metadata{"foo": &Metablock{Signed: Link{Name: "foo", Materials: map[string]HashObj{"./bar/..//foo.py": HashObj{"sha265": "abc"}}}}},
 			expectErr: "",
 		},
 		{
 			name:      "Consuming filename product in inspection",
 			item:      []interface{}{Inspection{SupplyChainItem: SupplyChainItem{Name: "foo", ExpectedProducts: [][]string{{"ALLOW", "foo.py"}, {"DISALLOW", "*"}}}}},
-			metadata:  map[string]Metadata{"foo": &Metablock{Signed: Link{Name: "foo", Products: map[string]interface{}{"./bar/..//foo.py": map[string]interface{}{"sha265": "abc"}}}}},
+			metadata:  map[string]Metadata{"foo": &Metablock{Signed: Link{Name: "foo", Products: map[string]HashObj{"./bar/..//foo.py": {"sha265": "abc"}}}}},
 			expectErr: "",
 		},
 	}
@@ -585,71 +585,71 @@ func TestVerifyMatchRule(t *testing.T) {
 	var testCases = []struct {
 		name        string
 		rule        map[string]string
-		srcArtifact map[string]interface{}
+		srcArtifact map[string]HashObj
 		item        map[string]Metadata
 		expectSet   Set
 	}{
 		{
 			name:        "Can't find destination link (invalid rule)",
 			rule:        map[string]string{},
-			srcArtifact: map[string]interface{}{},
+			srcArtifact: map[string]HashObj{},
 			item:        map[string]Metadata{},
 			expectSet:   NewSet(),
 		},
 		{
 			name:        "Can't find destination link (empty metadata map)",
 			rule:        map[string]string{"pattern": "*", "dstName": "foo", "dstType": "materials"},
-			srcArtifact: map[string]interface{}{"foo.py": map[string]interface{}{"sha265": "abc"}},
+			srcArtifact: map[string]HashObj{"foo.py": {"sha265": "abc"}},
 			item:        map[string]Metadata{},
 			expectSet:   NewSet(),
 		},
 		{
 			name:        "Match material foo.py",
 			rule:        map[string]string{"pattern": "*", "dstName": "foo", "dstType": "materials"},
-			srcArtifact: map[string]interface{}{"foo.py": map[string]interface{}{"sha265": "abc"}},
-			item:        map[string]Metadata{"foo": &Metablock{Signed: Link{Name: "foo", Materials: map[string]interface{}{"foo.py": map[string]interface{}{"sha265": "abc"}}}}},
+			srcArtifact: map[string]HashObj{"foo.py": {"sha265": "abc"}},
+			item:        map[string]Metadata{"foo": &Metablock{Signed: Link{Name: "foo", Materials: map[string]HashObj{"foo.py": {"sha265": "abc"}}}}},
 			expectSet:   NewSet("foo.py"),
 		},
 		{
 			name:        "Match material foo.py with foo.d/foo.py",
 			rule:        map[string]string{"pattern": "*", "dstName": "foo", "dstType": "materials", "dstPrefix": "foo.d"},
-			srcArtifact: map[string]interface{}{"foo.py": map[string]interface{}{"sha265": "abc"}},
-			item:        map[string]Metadata{"foo": &Metablock{Signed: Link{Name: "foo", Materials: map[string]interface{}{"foo.d/foo.py": map[string]interface{}{"sha265": "abc"}}}}},
+			srcArtifact: map[string]HashObj{"foo.py": {"sha265": "abc"}},
+			item:        map[string]Metadata{"foo": &Metablock{Signed: Link{Name: "foo", Materials: map[string]HashObj{"foo.d/foo.py": HashObj{"sha265": "abc"}}}}},
 			expectSet:   NewSet("foo.py"),
 		},
 		{
 			name:        "Match material foo.d/foo.py with foo.py",
 			rule:        map[string]string{"pattern": "*", "dstName": "foo", "dstType": "materials", "srcPrefix": "foo.d"},
-			srcArtifact: map[string]interface{}{"foo.d/foo.py": map[string]interface{}{"sha265": "abc"}},
-			item:        map[string]Metadata{"foo": &Metablock{Signed: Link{Name: "foo", Materials: map[string]interface{}{"foo.py": map[string]interface{}{"sha265": "abc"}}}}},
+			srcArtifact: map[string]HashObj{"foo.d/foo.py": {"sha265": "abc"}},
+			item:        map[string]Metadata{"foo": &Metablock{Signed: Link{Name: "foo", Materials: map[string]HashObj{"foo.py": HashObj{"sha265": "abc"}}}}},
 			expectSet:   NewSet("foo.d/foo.py"),
 		},
 		{
 			name:        "Don't match material (different name)",
 			rule:        map[string]string{"pattern": "*", "dstName": "foo", "dstType": "materials"},
-			srcArtifact: map[string]interface{}{"bar.py": map[string]interface{}{"sha265": "abc"}},
-			item:        map[string]Metadata{"foo": &Metablock{Signed: Link{Name: "foo", Materials: map[string]interface{}{"foo.py": map[string]interface{}{"sha265": "abc"}}}}},
+			srcArtifact: map[string]HashObj{"bar.py": {"sha265": "abc"}},
+			item:        map[string]Metadata{"foo": &Metablock{Signed: Link{Name: "foo", Materials: map[string]HashObj{"foo.py": {"sha265": "abc"}}}}},
 			expectSet:   NewSet(),
 		},
 		{
 			name:        "Don't match material (different hash)",
 			rule:        map[string]string{"pattern": "*", "dstName": "foo", "dstType": "materials"},
-			srcArtifact: map[string]interface{}{"foo.py": map[string]interface{}{"sha265": "dead"}},
-			item:        map[string]Metadata{"foo": &Metablock{Signed: Link{Name: "foo", Materials: map[string]interface{}{"foo.py": map[string]interface{}{"sha265": "abc"}}}}},
+			srcArtifact: map[string]HashObj{"foo.py": {"sha265": "dead"}},
+			item:        map[string]Metadata{"foo": &Metablock{Signed: Link{Name: "foo", Materials: map[string]HashObj{"foo.py": {"sha265": "abc"}}}}},
 			expectSet:   NewSet(),
 		},
 		{
 			name:        "Match material in sub-directories dir/foo.py",
 			rule:        map[string]string{"pattern": "*", "dstName": "foo", "dstType": "materials"},
-			srcArtifact: map[string]interface{}{"bar/foo.py": map[string]interface{}{"sha265": "abc"}},
-			item:        map[string]Metadata{"foo": &Metablock{Signed: Link{Name: "foo", Materials: map[string]interface{}{"bar/foo.py": map[string]interface{}{"sha265": "abc"}}}}},
+			srcArtifact: map[string]HashObj{"bar/foo.py": {"sha265": "abc"}},
+			item:        map[string]Metadata{"foo": &Metablock{Signed: Link{Name: "foo", Materials: map[string]HashObj{"bar/foo.py": {"sha265": "abc"}}}}},
 			expectSet:   NewSet("bar/foo.py"),
 		},
 	}
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			queue := NewSet(InterfaceKeyStrings(tt.srcArtifact)...)
+			queue := NewSet(artifactsDictKeyStrings(tt.srcArtifact)...)
 			result := verifyMatchRule(tt.rule, tt.srcArtifact, queue, tt.item)
 			if !reflect.DeepEqual(result, tt.expectSet) {
 				t.Errorf("verifyMatchRule returned '%s', expected '%s'", result, tt.expectSet)
@@ -672,14 +672,14 @@ func TestReduceStepsMetadata(t *testing.T) {
 			"a": &Metablock{Signed: Link{
 				Type:      "link",
 				Name:      "foo",
-				Materials: map[string]interface{}{"foo.py": map[string]interface{}{"sha265": "abc"}},
-				Products:  map[string]interface{}{"bar.py": map[string]interface{}{"sha265": "cde"}},
+				Materials: map[string]HashObj{"foo.py": {"sha265": "abc"}},
+				Products:  map[string]HashObj{"bar.py": {"sha265": "cde"}},
 			}},
 			"b": &Metablock{Signed: Link{
 				Type:      "link",
 				Name:      "foo",
-				Materials: map[string]interface{}{"foo.py": map[string]interface{}{"sha265": "abc"}},
-				Products:  map[string]interface{}{"bar.py": map[string]interface{}{"sha265": "cde"}},
+				Materials: map[string]HashObj{"foo.py": {"sha265": "abc"}},
+				Products:  map[string]HashObj{"bar.py": {"sha265": "cde"}},
 			}},
 		},
 	}
@@ -698,20 +698,20 @@ func TestReduceStepsMetadata(t *testing.T) {
 	// - Different products (name)
 	stepsMetadataList := []map[string]map[string]Metadata{
 		{"foo": {
-			"a": &Metablock{Signed: Link{Materials: map[string]interface{}{"foo.py": map[string]interface{}{"sha265": "abc"}}}},
-			"b": &Metablock{Signed: Link{Materials: map[string]interface{}{"foo.py": map[string]interface{}{"sha265": "def"}}}},
+			"a": &Metablock{Signed: Link{Materials: map[string]HashObj{"foo.py": {"sha265": "abc"}}}},
+			"b": &Metablock{Signed: Link{Materials: map[string]HashObj{"foo.py": {"sha265": "def"}}}},
 		}},
 		{"foo": {
-			"a": &Metablock{Signed: Link{Materials: map[string]interface{}{"foo.py": map[string]interface{}{"sha265": "abc"}}}},
-			"b": &Metablock{Signed: Link{Materials: map[string]interface{}{"bar.py": map[string]interface{}{"sha265": "abc"}}}},
+			"a": &Metablock{Signed: Link{Materials: map[string]HashObj{"foo.py": {"sha265": "abc"}}}},
+			"b": &Metablock{Signed: Link{Materials: map[string]HashObj{"bar.py": {"sha265": "abc"}}}},
 		}},
 		{"foo": {
-			"a": &Metablock{Signed: Link{Products: map[string]interface{}{"foo.py": map[string]interface{}{"sha265": "abc"}}}},
-			"b": &Metablock{Signed: Link{Products: map[string]interface{}{"foo.py": map[string]interface{}{"sha265": "def"}}}},
+			"a": &Metablock{Signed: Link{Products: map[string]HashObj{"foo.py": {"sha265": "abc"}}}},
+			"b": &Metablock{Signed: Link{Products: map[string]HashObj{"foo.py": {"sha265": "def"}}}},
 		}},
 		{"foo": {
-			"a": &Metablock{Signed: Link{Products: map[string]interface{}{"foo.py": map[string]interface{}{"sha265": "abc"}}}},
-			"b": &Metablock{Signed: Link{Products: map[string]interface{}{"bar.py": map[string]interface{}{"sha265": "abc"}}}},
+			"a": &Metablock{Signed: Link{Products: map[string]HashObj{"foo.py": {"sha265": "abc"}}}},
+			"b": &Metablock{Signed: Link{Products: map[string]HashObj{"bar.py": {"sha265": "abc"}}}},
 		}},
 	}
 


### PR DESCRIPTION
**Fixes issue:**
N/A

**Description:**
We know that hash objects are a map from string to string. We can therefore set that expectation directly rather than using interface types.

**Please verify and check that the pull request fulfills the following
requirements:**

- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


