### PR TITLE
Remove unfinished link on record stop

### DIFF
--- a/cmd/record.go
+++ b/cmd/record.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	intoto "github.com/in-toto/in-toto-golang/in_toto"
@@ -205,6 +206,11 @@ func recordStop(cmd *cobra.Command, args []string) error {
 	err = linkMb.Dump(linkPath)
 	if err != nil {
 		return fmt.Errorf("failed to write stop link file to %s: %w", prelimLinkName, err)
+	}
+
+	err = os.Remove(prelimLinkPath)
+	if err != nil {
+		return fmt.Errorf("failed to remove start link file at %s: %w", prelimLinkName, err)
 	}
 
 	return nil


### PR DESCRIPTION
**Fixes issue:**
Fixes #244 

**Description:**
in-toto-golang record doesn't removes unifinished link on stop. Which creates an implementation difference between in-toto implemenations.
This is fixed by removing unfinished link at the record CLI.

**Please verify and check that the pull request fulfills the following
requirements:**

- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


