### PR TITLE
Fixes filepath pattern matching in windows

### DIFF
--- a/in_toto/runlib.go
+++ b/in_toto/runlib.go
@@ -95,18 +95,19 @@ return value is the error.
 func RecordArtifacts(paths []string, hashAlgorithms []string, gitignorePatterns []string, lStripPaths []string, lineNormalization bool, followSymlinkDirs bool) (evalArtifacts map[string]interface{}, err error) {
 	// Make sure to initialize a fresh hashset for every RecordArtifacts call
 	visitedSymlinks = NewSet()
-	evalArtifacts, err = recordArtifacts(paths, hashAlgorithms, gitignorePatterns, lStripPaths, lineNormalization, followSymlinkDirs)
-	// normalize windows paths to unix paths
-	for key, value := range evalArtifacts {
-		delete(evalArtifacts, key)
-		key = filepath.ToSlash(key)
-
-		// Convert windows filepath to unix filepath.
-		evalArtifacts[key] = value
+	evalArtifactsUnnormalized, err := recordArtifacts(paths, hashAlgorithms, gitignorePatterns, lStripPaths, lineNormalization, followSymlinkDirs)
+	if err != nil {
+		return nil, err
 	}
 
-	// pass result and error through
-	return evalArtifacts, err
+	// Normalize all paths in evalArtifactsUnnormalized.
+	evalArtifacts = make(map[string]interface{})
+	for key, value := range evalArtifactsUnnormalized {
+		// Convert windows filepath to unix filepath.
+		evalArtifacts[filepath.ToSlash(key)] = value
+	}
+
+	return evalArtifacts, nil
 }
 
 /*

--- a/in_toto/runlib.go
+++ b/in_toto/runlib.go
@@ -101,7 +101,7 @@ func RecordArtifacts(paths []string, hashAlgorithms []string, gitignorePatterns 
 	}
 
 	// Normalize all paths in evalArtifactsUnnormalized.
-	evalArtifacts = make(map[string]interface{})
+	evalArtifacts = make(map[string]interface{}, len(evalArtifactsUnnormalized))
 	for key, value := range evalArtifactsUnnormalized {
 		// Convert windows filepath to unix filepath.
 		evalArtifacts[filepath.ToSlash(key)] = value

--- a/in_toto/runlib.go
+++ b/in_toto/runlib.go
@@ -96,6 +96,15 @@ func RecordArtifacts(paths []string, hashAlgorithms []string, gitignorePatterns 
 	// Make sure to initialize a fresh hashset for every RecordArtifacts call
 	visitedSymlinks = NewSet()
 	evalArtifacts, err = recordArtifacts(paths, hashAlgorithms, gitignorePatterns, lStripPaths, lineNormalization, followSymlinkDirs)
+	// normalize windows paths to unix paths
+	for key, value := range evalArtifacts {
+		delete(evalArtifacts, key)
+		key = filepath.ToSlash(key)
+
+		// Convert windows filepath to unix filepath.
+		evalArtifacts[key] = value
+	}
+
 	// pass result and error through
 	return evalArtifacts, err
 }

--- a/in_toto/runlib_test.go
+++ b/in_toto/runlib_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -221,7 +222,7 @@ func TestSymlinkToFolder(t *testing.T) {
 	}
 
 	expected := map[string]interface{}{
-		filepath.ToSlash(filepath.Join("symTmpfile.sym", "symTmpfile")): map[string]interface{}{
+		path.Join("symTmpfile.sym", "symTmpfile"): map[string]interface{}{
 			"sha256": "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
 		},
 	}

--- a/in_toto/runlib_test.go
+++ b/in_toto/runlib_test.go
@@ -221,7 +221,7 @@ func TestSymlinkToFolder(t *testing.T) {
 	}
 
 	expected := map[string]interface{}{
-		filepath.Join("symTmpfile.sym", "symTmpfile"): map[string]interface{}{
+		filepath.ToSlash(filepath.Join("symTmpfile.sym", "symTmpfile")): map[string]interface{}{
 			"sha256": "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
 		},
 	}


### PR DESCRIPTION
Fixes: #253 

**Description:**
Filepath works differently compared to linux, on testing found it didn't allowed the provided path pattern in windows. This is fixed using `filepath.Match` instead of `match`.

**Please verify and check that the pull request fulfills the following
requirements:**

- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature