### PR TITLE
Deprecate Provenance v1 struct in favor of /attestation protobufs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/google/go-cmp v0.5.9
+	github.com/in-toto/attestation v0.1.1-0.20230828220013-11b7a1a4ca51
 	github.com/secure-systems-lab/go-securesystemslib v0.7.0
 	github.com/shibumi/go-pathspec v1.3.0
 	github.com/spf13/cobra v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/in-toto/attestation v0.1.1-0.20230828220013-11b7a1a4ca51 h1:79cutIt/QsUDEWEPKUdC9OiI0C9fYxRuU1VvYTGYTuo=
+github.com/in-toto/attestation v0.1.1-0.20230828220013-11b7a1a4ca51/go.mod h1:hCR5COCuENh5+VfojEkJnt7caOymbEgvyZdKifD6pOw=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=

--- a/in_toto/attestations.go
+++ b/in_toto/attestations.go
@@ -22,12 +22,28 @@ const (
 )
 
 // Subject describes the set of software artifacts the statement applies to.
+//
+// Deprecated: This implementation of Subject exists for historical
+// compatibility and should not be used. This implementation has been
+// superseded by a ResourceDescriptor struct generated from the Protobuf
+// definition in
+// https://github.com/in-toto/attestation/tree/main/protos/in_toto_attestation/v1.
+// To generate an ITE-6 v1 Statement subject, use the ResourceDescriptor Go
+// APIs provided in https://github.com/in-toto/attestation/tree/main/go/v1.
 type Subject struct {
 	Name   string           `json:"name"`
 	Digest common.DigestSet `json:"digest"`
 }
 
 // StatementHeader defines the common fields for all statements
+//
+// Deprecated: This implementation of StatementHeader exists for historical
+// compatibility and should not be used. This implementation has been
+// superseded by the Statement struct generated from the Protobuf
+// definition in
+// https://github.com/in-toto/attestation/tree/main/protos/in_toto_attestation/v1.
+// To generate an ITE-6 v1 Statement, use the Go APIs provided in
+// https://github.com/in-toto/attestation/tree/main/go/v1.
 type StatementHeader struct {
 	Type          string    `json:"_type"`
 	PredicateType string    `json:"predicateType"`
@@ -38,6 +54,13 @@ type StatementHeader struct {
 Statement binds the attestation to a particular subject and identifies the
 of the predicate. This struct represents a generic statement.
 */
+// Deprecated: This implementation of Statement exists for historical
+// compatibility and should not be used. This implementation has been
+// superseded by the Statement struct generated from the Protobuf
+// definition in
+// https://github.com/in-toto/attestation/tree/main/protos/in_toto_attestation/v1.
+// To generate an ITE-6 v1 Statement, use the Go APIs provided in
+// https://github.com/in-toto/attestation/tree/main/go/v1.
 type Statement struct {
 	StatementHeader
 	// Predicate contains type speficic metadata.
@@ -57,6 +80,11 @@ type ProvenanceStatementSLSA02 struct {
 }
 
 // ProvenanceStatementSLSA1 is the definition for an entire provenance statement with SLSA 1.0 predicate.
+//
+// Deprecated: ProvenanceStatementSLSA1 exists for historical
+// compatibility and should not be used. To generate an ITE-6 v1 Statement
+// with an ITE-9 Provenance v1 predicate, use the Go APIs provided in
+// https://github.com/in-toto/attestation/tree/main/go.
 type ProvenanceStatementSLSA1 struct {
 	StatementHeader
 	Predicate slsa1.ProvenancePredicate `json:"predicate"`

--- a/in_toto/attestations.go
+++ b/in_toto/attestations.go
@@ -1,6 +1,7 @@
 package in_toto
 
 import (
+	ita1 "github.com/in-toto/attestation/go/v1"
 	"github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
 	slsa01 "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.1"
 	slsa02 "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
@@ -11,6 +12,11 @@ const (
 	// StatementInTotoV01 is the statement type for the generalized link format
 	// containing statements. This is constant for all predicate types.
 	StatementInTotoV01 = "https://in-toto.io/Statement/v0.1"
+
+	// StatementInTotoV1 is the type URI for ITE-6 v1 Statements.
+	// This is constant for all predicate types.
+	StatementInTotoV1 = ita1.StatementTypeUri
+	
 	// PredicateSPDX represents a SBOM using the SPDX standard.
 	// The SPDX mandates 'spdxVersion' field, so predicate type can omit
 	// version.

--- a/in_toto/attestations.go
+++ b/in_toto/attestations.go
@@ -16,7 +16,7 @@ const (
 	// StatementInTotoV1 is the type URI for ITE-6 v1 Statements.
 	// This is constant for all predicate types.
 	StatementInTotoV1 = ita1.StatementTypeUri
-	
+
 	// PredicateSPDX represents a SBOM using the SPDX standard.
 	// The SPDX mandates 'spdxVersion' field, so predicate type can omit
 	// version.

--- a/in_toto/slsa_provenance/v1/provenance.go
+++ b/in_toto/slsa_provenance/v1/provenance.go
@@ -12,6 +12,12 @@ const (
 )
 
 // ProvenancePredicate is the provenance predicate definition.
+//
+// Deprecated: ProvenancePredicate exists for historical compatibility
+// and should not be used. This implementation has been superseded by the
+// Provenance struct generated from the Protobuf definition provided
+// by the in-toto Attestation Framework.
+// https://github.com/in-toto/attestation/tree/main/protos/in_toto_attestation/predicates/provenance/v1.
 type ProvenancePredicate struct {
 	// The BuildDefinition describes all of the inputs to the build. The
 	// accuracy and completeness are implied by runDetails.builder.id.
@@ -25,6 +31,11 @@ type ProvenancePredicate struct {
 }
 
 // ProvenanceBuildDefinition describes the inputs to the build.
+//
+// Deprecated: ProvenanceBuildDefinition exists for historical compatibility
+// and should not be used. This implementation has been superseded by the
+// BuildDefinition struct generated from the Protobuf definition in
+// https://github.com/in-toto/attestation/tree/main/protos/in_toto_attestation/predicates/provenance/v1.
 type ProvenanceBuildDefinition struct {
 	// Identifies the template for how to perform the build and interpret the
 	// parameters and dependencies.
@@ -66,6 +77,11 @@ type ProvenanceBuildDefinition struct {
 
 // ProvenanceRunDetails includes details specific to a particular execution of a
 // build.
+//
+// Deprecated: ProvenanceRunDetails exists for historical compatibility
+// and should not be used. This implementation has been superseded by the
+// RunDetails struct generated from the Protobuf definition in
+// https://github.com/in-toto/attestation/tree/main/protos/in_toto_attestation/predicates/provenance/v1.
 type ProvenanceRunDetails struct {
 	// Identifies the entity that executed the invocation, which is trusted to
 	// have correctly performed the operation and populated this provenance.
@@ -92,6 +108,12 @@ type ProvenanceRunDetails struct {
 // ResourceDescriptor describes a particular software artifact or resource
 // (mutable or immutable).
 // See https://github.com/in-toto/attestation/blob/main/spec/v1.0/resource_descriptor.md
+//
+// Deprecated: This implementation of ResoureDescriptor exists for
+// historical compatibility and should not be used. This struct has been
+// superseded by the ResourceDescriptor struct generated from the Protobuf
+// definition in
+// https://github.com/in-toto/attestation/tree/main/protos/in_toto_attestation/v1.
 type ResourceDescriptor struct {
 	// A URI used to identify the resource or artifact globally. This field is
 	// REQUIRED unless either digest or content is set.
@@ -123,6 +145,11 @@ type ResourceDescriptor struct {
 
 // Builder represents the transitive closure of all the entities that are, by
 // necessity, trusted to faithfully run the build and record the provenance.
+//
+// Deprecated: This implementation of Builder exists for historical
+// compatibility and should not be used. This implementation has been
+// superseded by the Builder struct generated from the Protobuf definition in
+// https://github.com/in-toto/attestation/tree/main/protos/in_toto_attestation/predicates/provenance/v1.
 type Builder struct {
 	// URI indicating the transitive closure of the trusted builder.
 	ID string `json:"id"`
@@ -136,6 +163,11 @@ type Builder struct {
 	BuilderDependencies []ResourceDescriptor `json:"builderDependencies,omitempty"`
 }
 
+// Deprecated: This implementation of BuildMetadata exists for historical
+// compatibility and should not be used. This implementation has been
+// superseded by the BuildMetadata struct generated from the Protobuf
+// definition in
+// https://github.com/in-toto/attestation/tree/main/protos/in_toto_attestation/predicates/provenance/v1.
 type BuildMetadata struct {
 	// Identifies this particular build invocation, which can be useful for
 	// finding associated logs or other ad-hoc analysis. The exact meaning and


### PR DESCRIPTION
This PR is the first step towards making in-toto-golang ITE-9 compatible. It deprecates the SLSA Provenance v1 and ITE-6 structs defined in this package, which have fallen out of spec and been superseded by the pre-generated Go bindings based on the [proto definitions](https://github.com/in-toto/attestation/tree/main/protos) in the ITE-6/ITE-9 [attestation repo](https://github.com/in-toto/attestation).

Fixes #265 and #260 .

