### PR TITLE
Trigger workflow on pushes only to master branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,7 @@
-on: [push, pull_request]
+on:
+  push:
+    branches: ['master']
+  pull_request:
 name: build
 jobs:
   test:

--- a/.github/workflows/verify-docgen-fmt.yml
+++ b/.github/workflows/verify-docgen-fmt.yml
@@ -3,7 +3,7 @@ name: Docgen and go fmt
 on:
   workflow_dispatch:
   push:
-    branches: ['main', 'release-*']
+    branches: ['master']
   pull_request:
 
 jobs:


### PR DESCRIPTION
**Fixes issue:** N/A


**Description:**

Currently, PRs opened from the main repository (such as dependabot) trigger workflows twice. By limiting it to pushes to the master branch only, we avoid the double CI execution.

**Please verify and check that the pull request fulfills the following
requirements:**

- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


