### PR TITLE
Add LinkAttestor for in-toto Attestation Framework Link Predicate

### DIFF
--- a/doc/in-toto_run.md
+++ b/doc/in-toto_run.md
@@ -17,6 +17,9 @@ in-toto run [flags]
 ### Options
 
 ```
+  -a, --attestations stringArray          Create metadata using Attestation Framework.
+                                          Attestation accepts a list of supported predicate types.
+                                          Note: Currently only 'link' is supported.
   -c, --cert string                       Path to a PEM formatted certificate that corresponds with
                                           the provided key.
   -e, --exclude stringArray               Path patterns to match paths that should not be recorded as 0

--- a/in_toto/attestations.go
+++ b/in_toto/attestations.go
@@ -1,11 +1,15 @@
 package in_toto
 
 import (
+	link "github.com/in-toto/attestation/go/predicates/link/v0"
 	ita1 "github.com/in-toto/attestation/go/v1"
+	v1 "github.com/in-toto/attestation/go/v1"
 	"github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/common"
 	slsa01 "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.1"
 	slsa02 "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
 	slsa1 "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v1"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 const (
@@ -23,8 +27,15 @@ const (
 	PredicateSPDX = "https://spdx.dev/Document"
 	// PredicateCycloneDX represents a CycloneDX SBOM
 	PredicateCycloneDX = "https://cyclonedx.org/bom"
-	// PredicateLinkV1 represents an in-toto 0.9 link.
+
+	/*
+		Deprecated - use PredicateLink instead
+		PredicateLinkV1 represents an in-toto 0.9 link.
+	*/
 	PredicateLinkV1 = "https://in-toto.io/Link/v1"
+
+	// Represents an in-toto link predicate
+	PredicateLink = "https://in-toto.io/attestation/link/v0.3"
 )
 
 // Subject describes the set of software artifacts the statement applies to.
@@ -130,4 +141,138 @@ interface, like the generic Statement.
 type CycloneDXStatement struct {
 	StatementHeader
 	Predicate interface{} `json:"predicate"`
+}
+
+/*
+An Attestor is used to create in-toto Attestation
+framework compliant metadata.
+
+  - GenerateStatement exists to enable usage of alternative
+    signing solutions.
+  - Attest supports using the DSSE for signing
+*/
+type Attestor interface {
+	GenerateStatement() (*v1.Statement, error)
+	Attest() (*Envelope, error)
+}
+
+/*
+LinkAttestor follows the in-toto Attestation framework
+for a Link Predicate.
+*/
+type LinkAttestor struct {
+	MaterialPaths     []string
+	ProductPaths      []string
+	HashAlgorithms    []string
+	GitignorePatterns []string
+	LStripPaths       []string
+	CmdArgs           []string
+	RunDir            string
+	StepName          string
+	LineNormalization bool
+	FollowSymlinkDirs bool
+	Key               Key
+}
+
+func (a *LinkAttestor) Attest() (*Envelope, error) {
+	statement, err := a.GenerateStatement()
+	if err != nil {
+		return nil, err
+	}
+
+	return signStatement(statement, a.Key)
+}
+
+func (a *LinkAttestor) GenerateStatement() (*v1.Statement, error) {
+	materials, err := RecordArtifacts(a.MaterialPaths, a.HashAlgorithms, a.GitignorePatterns, a.LStripPaths, a.LineNormalization, a.FollowSymlinkDirs)
+	if err != nil {
+		return nil, err
+	}
+
+	// make sure that we only run RunCommand if cmdArgs is not nil or empty
+	byProducts := map[string]interface{}{}
+	if len(a.CmdArgs) != 0 {
+		byProducts, err = RunCommand(a.CmdArgs, a.RunDir)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	products, err := RecordArtifacts(a.ProductPaths, a.HashAlgorithms, a.GitignorePatterns, a.LStripPaths, a.LineNormalization, a.FollowSymlinkDirs)
+	if err != nil {
+		return nil, err
+	}
+
+	var materialResources = make([]*v1.ResourceDescriptor, len(materials))
+	matCount := 0
+	for key, value := range materials {
+		materialResources[matCount] = &v1.ResourceDescriptor{
+			Name:   key,
+			Digest: value,
+		}
+
+		matCount++
+	}
+
+	var productResources = make([]*v1.ResourceDescriptor, len(products))
+	prdCount := 0
+	for key, value := range products {
+		productResources[0] = &v1.ResourceDescriptor{
+			Name:   key,
+			Digest: value,
+		}
+
+		prdCount++
+	}
+
+	byProductsStruct, err := structpb.NewStruct(byProducts)
+	if err != nil {
+		return nil, err
+	}
+
+	link := link.Link{
+		Name:       a.StepName,
+		Command:    a.CmdArgs,
+		Materials:  materialResources,
+		Byproducts: byProductsStruct,
+	}
+
+	linkJson, err := protojson.Marshal(&link)
+	if err != nil {
+		return nil, err
+	}
+
+	linkStruct := &structpb.Struct{}
+	err = protojson.Unmarshal(linkJson, linkStruct)
+	if err != nil {
+		return nil, err
+	}
+
+	statement := v1.Statement{
+		Type:          StatementInTotoV1,
+		Subject:       productResources,
+		PredicateType: PredicateLink,
+		Predicate:     linkStruct,
+	}
+
+	err = statement.Validate()
+	if err != nil {
+		return nil, err
+	}
+
+	return &statement, nil
+}
+
+func signStatement(statement *v1.Statement, key Key) (*Envelope, error) {
+	env := &Envelope{}
+	if err := env.SetPayloadProtobuf(statement); err != nil {
+		return nil, err
+	}
+
+	err := env.Sign(key)
+	if err != nil {
+		return nil, err
+	}
+
+	return env, nil
 }

--- a/in_toto/envelope.go
+++ b/in_toto/envelope.go
@@ -8,9 +8,11 @@ import (
 	"fmt"
 	"os"
 
+	v1 "github.com/in-toto/attestation/go/v1"
 	"github.com/secure-systems-lab/go-securesystemslib/cjson"
 	"github.com/secure-systems-lab/go-securesystemslib/dsse"
 	"github.com/secure-systems-lab/go-securesystemslib/signerverifier"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 // PayloadType is the payload type used for links and layouts.
@@ -43,6 +45,21 @@ func loadEnvelope(env *dsse.Envelope) (*Envelope, error) {
 
 func (e *Envelope) SetPayload(payload any) error {
 	encodedBytes, err := cjson.EncodeCanonical(payload)
+	if err != nil {
+		return err
+	}
+
+	e.payload = payload
+	e.envelope = &dsse.Envelope{
+		Payload:     base64.StdEncoding.EncodeToString(encodedBytes),
+		PayloadType: PayloadType,
+	}
+
+	return nil
+}
+
+func (e *Envelope) SetPayloadProtobuf(payload *v1.Statement) error {
+	encodedBytes, err := protojson.Marshal(payload)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This change adds a "LinkAttestor" which is able to create in-toto Attestation compliant metadata for a link predicate.

I experimented with a variety of ways to implement this, but chose to add an Attestor type over updating the InTotoRun function to include this capability (like how --use-dsse is implemented).

This is added with the thought that additional attestation predicate types may be supported in the future. In addition, I assume that we may not want to use DSSE for all signing operations (thus support creating an unsigned statement).

This won't work with layouts as there isn't a layout structure for the Attestation framework yet, I believe.

The Attestor code can easily be moved into its own package if desired. I'm not certain what other Attestors, if any, should be supported, but this can probably be made more dynamic if needed.

A smidge of code is duplicated, which can be cleaned up, but I didn't want to touch the v1 code too much for this submission.
 
Example usage;

```
mkdir testingdir
cd testingdir
go run .. run -k ../test/data/carol -m . -p helloworld -n test -a link -- touch helloworld
```

Output:

```
{
  "payloadType": "application/vnd.in-toto+json",
  "payload": "eyJwcmVkaWNhdGUiOnsiYnlwcm9kdWN0cyI6eyJyZXR1cm4tdmFsdWUiOjAsInN0ZGVyciI6IiIsInN0ZG91dCI6IiJ9LCJjb21tYW5kIjpbInRvdWNoIiwiaGVsbG93b3JsZCJdLCJuYW1lIjoidGVzdCJ9LCJwcmVkaWNhdGVfdHlwZSI6Imh0dHBzOi8vaW4tdG90by5pby9MaW5rL3YxIiwic3ViamVjdCI6W3siZGlnZXN0Ijp7InNoYTI1NiI6ImUzYjBjNDQyOThmYzFjMTQ5YWZiZjRjODk5NmZiOTI0MjdhZTQxZTQ2NDliOTM0Y2E0OTU5OTFiNzg1MmI4NTUifSwibmFtZSI6ImhlbGxvd29ybGQifV0sInR5cGUiOiJodHRwczovL2luLXRvdG8uaW8vU3RhdGVtZW50L3YxIn0=",
  "signatures": [
    {
      "keyid": "be6371bc627318218191ce0780fd3183cce6c36da02938a477d2e4dfae1804a6",
      "sig": "rMeB/jUl6/zZh9Kms3BK0ZnrCJChd3Y82e5ROuWnpq+vOxWwDff3zyieOrnItlhi13u2DxAkAG/oKpiXlGuZDQ=="
    }
  ]
}
```

Decoded Payload;

```
{
    "predicate": {
        "byproducts": {
            "return-value": 0,
            "stderr": "",
            "stdout": ""
        },
        "command": [
            "touch",
            "helloworld"
        ],
        "name": "test"
    },
    "predicate_type": "https://in-toto.io/attestation/link/v0.3",
    "subject": [
        {
            "digest": {
                "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
            },
            "name": "helloworld"
        }
    ],
    "type": "https://in-toto.io/Statement/v1"
}
```

edit: fixed predicate string to use latest version over deprecated.

- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


