### PR TITLE
Fix serialization of SLSA BuildMetadata.InvocationID

### DIFF
--- a/in_toto/slsa_provenance/v1/provenance.go
+++ b/in_toto/slsa_provenance/v1/provenance.go
@@ -173,7 +173,7 @@ type BuildMetadata struct {
 	// finding associated logs or other ad-hoc analysis. The exact meaning and
 	// format is defined by builder.id; by default it is treated as opaque and
 	// case-sensitive. The value SHOULD be globally unique.
-	InvocationID string `json:"invocationID,omitempty"`
+	InvocationID string `json:"invocationId,omitempty"`
 
 	// The timestamp of when the build started.
 	StartedOn *time.Time `json:"startedOn,omitempty"`

--- a/in_toto/slsa_provenance/v1/provenance_test.go
+++ b/in_toto/slsa_provenance/v1/provenance_test.go
@@ -127,7 +127,7 @@ func TestMetadataNoTime(t *testing.T) {
 	var md = BuildMetadata{
 		InvocationID: "123456-12-1",
 	}
-	var want = `{"invocationID":"123456-12-1"}`
+	var want = `{"invocationId":"123456-12-1"}`
 	var got BuildMetadata
 	b, err := json.Marshal(&md)
 


### PR DESCRIPTION
per the docs, the correct serialization is "invocationId": https://slsa.dev/spec/v1.0/provenance#:~:text=%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%22-,invocationId,-%22%3A%20old

This aligns this (deprecated) version with the proto-based one in in-toto/attestation: https://github.com/in-toto/attestation/blob/main/go/predicates/provenance/v1/provenance.pb.go#L287C85-L287C97

**Fixes issue:**

Fixes #260

**Description:**


**Please verify and check that the pull request fulfills the following
requirements:**

- [X] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature